### PR TITLE
Switch to codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,18 +50,14 @@ jobs:
       env:
         TOXENV: ${{ matrix.TOXENV }}
       run: tox
-    - name: Submit to coveralls
-      uses: AndreMiras/coveralls-python-action@develop
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v2
+      env:
+        TOXENV: ${{ matrix.TOXENV }}
       with:
-        parallel: true
-        github-token: ${{ secrets.github_token }}
-
-  coverage:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-    - name: Coveralls Finished
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.github_token }}
-        parallel-finished: true
+        env_vars: TOXENV
+        fail_ci_if_error: true
+        flags: unittests
+        name: codecov-umbrella
+        verbose: true
+        files: ./coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ pip-log.txt
 .tox
 nosetests.xml
 .pytest_cache
+coverage.xml
 
 #Translations
 *.mo

--- a/README.rst
+++ b/README.rst
@@ -5,9 +5,9 @@ InstrumentKit
     :target: https://github.com/instrumentkit/InstrumentKit
     :alt: Github Actions build status
 
-.. image:: https://img.shields.io/coveralls/instrumentkit/InstrumentKit/main.svg?maxAge=2592000
-    :target: https://coveralls.io/github/instrumentkit/InstrumentKit?branch=main
-    :alt: Coveralls code coverage
+.. image:: https://codecov.io/gh/instrumentkit/InstrumentKit/branch/main/graph/badge.svg?token=Q2wcdW3t4A
+    :target: https://codecov.io/gh/instrumentkit/InstrumentKit
+    :alt: Codecov code coverage
 
 .. image:: https://readthedocs.org/projects/instrumentkit/badge/?version=latest
     :target: https://readthedocs.org/projects/instrumentkit/?badge=latest

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ isolated_build = true
 extras = dev
 deps =
     numpy: numpy
-commands = pytest -n auto --cov=instruments {toxinidir}/instruments/tests/ {posargs:}
+commands = pytest -n auto --cov=instruments --cov-report=xml {toxinidir}/instruments/tests/ {posargs:}
 
 [testenv:precommit]
 basepython = python3


### PR DESCRIPTION
With the move to a new `instrumentkit` org, we weren't able to bring forward all the coveralls code coverage history. And to be honest, the UI, tools, and documentation were all pretty janky. So I gave codecov a shot and it seems to be smoother sailing. We'll give that a try and see if we like it.