### PR TITLE
Add 'instrumentkit' as owner requirement to workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
     - name: Run static checks via pre-commit
       run: SKIP=no-commit-to-branch pre-commit run --all --show-diff-on-failure
   test:
+    if: github.repository_owner == 'instrumentkit'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
     - name: Run static checks via pre-commit
       run: SKIP=no-commit-to-branch pre-commit run --all --show-diff-on-failure
   test:
-    if: github.repository_owner == 'instrumentkit'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -52,6 +51,7 @@ jobs:
         TOXENV: ${{ matrix.TOXENV }}
       run: tox
     - name: Upload coverage to Codecov
+      if: github.repository_owner == 'instrumentkit'
       uses: codecov/codecov-action@v2
       env:
         TOXENV: ${{ matrix.TOXENV }}


### PR DESCRIPTION
Updating my fork by merging the updated branch into it seems to run the tests now. Static checks pass, however (and of course), the actual tests fails when trying to push to codecov. 

Here, the proposed change is to check if the owner is `instrumentkit` and if so, run the tests, otherwise not. Alternatively, we probably could only make the codecov push owner dependent and keep the tests, running even on forks.