### PR TITLE
Fix HypothesisDeprecationWarning

### DIFF
--- a/tests/test_comm/test_usb_communicator.py
+++ b/tests/test_comm/test_usb_communicator.py
@@ -5,7 +5,8 @@ Unit tests for the USB communicator.
 
 # IMPORTS ####################################################################
 
-from hypothesis import given, strategies as st
+import math
+
 import pytest
 
 import usb.core
@@ -109,7 +110,7 @@ def test_terminator_wrong_type(inst):
     )
 
 
-@given(val=st.integers(min_value=1))
+@pytest.mark.parametrize("val", [1, 1000, math.inf])
 def test_timeout_get(val, inst):
     """Get a timeout from device (ms) and turn into s."""
     # mock timeout value of device

--- a/tests/test_keithley/test_keithley195.py
+++ b/tests/test_keithley/test_keithley195.py
@@ -27,13 +27,13 @@ from instruments.units import ureg as u
 # PYTEST FIXTURES FOR INITIALIZATION #
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def init():
     """Returns the initialization command that is sent to instrument."""
     return "YX\nG1DX"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def statusword():
     """Return a standard statusword for the status of the instrument."""
     trigger = b"1"  # talk_one_shot

--- a/tests/test_keithley/test_keithley580.py
+++ b/tests/test_keithley/test_keithley580.py
@@ -29,13 +29,13 @@ from instruments.units import ureg as u
 # PYTEST FIXTURES FOR INITIALIZATION #
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def init():
     """Returns the initialization command that is sent to instrument."""
     return "Y:X:"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def create_statusword():
     """Create a function that can create a status word.
 
@@ -83,7 +83,7 @@ def create_statusword():
     return make_statusword
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def create_measurement():
     """Create a function that can create a measurement.
 

--- a/tests/test_newport/test_newportesp301.py
+++ b/tests/test_newport/test_newportesp301.py
@@ -6,6 +6,7 @@ Unit tests for the Newport ESP 301 axis controller
 # IMPORTS #####################################################################
 
 import time
+from unittest import mock
 
 from hypothesis import given, strategies as st
 import pytest
@@ -175,22 +176,22 @@ def test_reset(mocker):
 
 
 @given(prg_id=st.integers(min_value=1, max_value=100))
-def test_define_program(mocker, prg_id):
+def test_define_program(prg_id):
     """Define an empty program.
 
     Mock out the `_newport_cmd` routine. Already tested and not
     required.
     """
     with expected_protocol(ik.newport.NewportESP301, [], [], sep="\r") as inst:
-        mock_cmd = mocker.patch.object(inst, "_newport_cmd")
-        with inst.define_program(prg_id):
-            pass
-        calls = (
-            mocker.call("XX", target=prg_id),
-            mocker.call("EP", target=prg_id),
-            mocker.call("QP"),
-        )
-        mock_cmd.has_calls(calls)
+        with mock.patch.object(inst, "_newport_cmd") as mock_cmd:
+            with inst.define_program(prg_id):
+                pass
+            calls = (
+                mock.call("XX", target=prg_id),
+                mock.call("EP", target=prg_id),
+                mock.call("QP"),
+            )
+            mock_cmd.has_calls(calls)
 
 
 @given(prg_id=st.integers().filter(lambda x: x < 1 or x > 100))
@@ -244,16 +245,16 @@ def test_execute_bulk_command(mocker, errcheck):
 
 
 @given(prg_id=st.integers(min_value=1, max_value=100))
-def test_run_program(mocker, prg_id):
+def test_run_program(prg_id):
     """Run a program.
 
     Mock out the `_newport_cmd` routine. Already tested and not
     required.
     """
     with expected_protocol(ik.newport.NewportESP301, [], [], sep="\r") as inst:
-        mock_cmd = mocker.patch.object(inst, "_newport_cmd")
-        inst.run_program(prg_id)
-        mock_cmd.assert_called_with("EX", target=prg_id)
+        with mock.patch.object(inst, "_newport_cmd") as mock_cmd:
+            inst.run_program(prg_id)
+            mock_cmd.assert_called_with("EX", target=prg_id)
 
 
 @given(prg_id=st.integers().filter(lambda x: x < 1 or x > 100))
@@ -1690,7 +1691,7 @@ def test_axis_setup_axis_torque(mocker):
 
 
 @given(rmt_time=st.integers().filter(lambda x: x < 0 or x > 60000))
-def test_axis_setup_axis_torque_time_out_of_range(mocker, rmt_time):
+def test_axis_setup_axis_torque_time_out_of_range(rmt_time):
     """Raise ValueError when time is out of range.
 
     Mock out `_newport_cmd` since tested elsewhere.
@@ -1731,9 +1732,9 @@ def test_axis_setup_axis_torque_time_out_of_range(mocker, rmt_time):
         ik.newport.NewportESP301, [ax_init[0]], [ax_init[1]], sep="\r"
     ) as inst:
         axis = inst.axis[0]
-        mocker.patch.object(axis, "_newport_cmd")
-        mocker.patch.object(axis, "read_setup", return_value=True)
-        with pytest.raises(ValueError) as err_info:
+        with mock.patch.object(axis, "_newport_cmd"), mock.patch.object(
+            axis, "read_setup", return_value=True
+        ), pytest.raises(ValueError) as err_info:
             axis.setup_axis(
                 motor_type=motor_type,
                 current=current,
@@ -1772,7 +1773,7 @@ def test_axis_setup_axis_torque_time_out_of_range(mocker, rmt_time):
 
 
 @given(rmt_perc=st.integers().filter(lambda x: x < 0 or x > 100))
-def test_axis_setup_axis_torque_percentage_out_of_range(mocker, rmt_perc):
+def test_axis_setup_axis_torque_percentage_out_of_range(rmt_perc):
     """Raise ValueError when time is out of range.
 
     Mock out `_newport_cmd` since tested elsewhere.
@@ -1813,9 +1814,9 @@ def test_axis_setup_axis_torque_percentage_out_of_range(mocker, rmt_perc):
         ik.newport.NewportESP301, [ax_init[0]], [ax_init[1]], sep="\r"
     ) as inst:
         axis = inst.axis[0]
-        mocker.patch.object(axis, "_newport_cmd")
-        mocker.patch.object(axis, "read_setup", return_value=True)
-        with pytest.raises(ValueError) as err_info:
+        with mock.patch.object(axis, "_newport_cmd"), mock.patch.object(
+            axis, "read_setup", return_value=True
+        ), pytest.raises(ValueError) as err_info:
             axis.setup_axis(
                 motor_type=motor_type,
                 current=current,

--- a/tests/test_tektronix/test_tktds5xx.py
+++ b/tests/test_tektronix/test_tktds5xx.py
@@ -10,6 +10,7 @@ Tests for the Tektronix TDS 5xx series oscilloscope.
 from datetime import datetime
 import struct
 import time
+from unittest import mock
 
 from hypothesis import (
     given,
@@ -680,6 +681,7 @@ def test_display_clock_value_error():
 
 
 @given(data=st.binary(min_size=1, max_size=2147483647))
+@mock.patch.object(time, "sleep", return_value=None)
 def test_get_hardcopy(mocker, data):
     """Transfer data in binary from the instrument.
 
@@ -694,8 +696,6 @@ def test_get_hardcopy(mocker, data):
     in header are filled with zeros.
     Mocking out sleep to do nothing.
     """
-    # mock out time
-    mocker.patch.object(time, "sleep", return_value=None)
 
     # make data
     length_data = (len(data) - 8) * 8  # subtract header and color table

--- a/tests/test_thorlabs/test_thorlabs_apt.py
+++ b/tests/test_thorlabs/test_thorlabs_apt.py
@@ -276,7 +276,7 @@ def init_ksg101():
     return stdin, stdout
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def init_kpz001():
     """Return the send, receive value to initialize a KPZ001 unit."""
     stdin = ThorLabsPacket(


### PR DESCRIPTION
Hypothesis started to point out that using hypothesis.given in combination with pytest fixtures, that the fixtures don't reset in between hypothesis iterations.

This changes some of the fixtures around, or changes their scope, to remove the warnings. I believe these warnings become errors in newer versions, so this is a blocker to updating

fyi @trappitsch 