### PR TITLE
Ensure a correctly encoded input for manual input.

### DIFF
--- a/src/instruments/abstract_instruments/comm/loopback_communicator.py
+++ b/src/instruments/abstract_instruments/comm/loopback_communicator.py
@@ -121,7 +121,7 @@ class LoopbackCommunicator(io.IOBase, AbstractCommunicator):
             else:
                 raise ValueError("Must read a positive value of characters.")
         else:
-            input_var = input("Desired Response: ")
+            input_var = input("Desired Response: ").encode("utf-8")
         return input_var
 
     def write_raw(self, msg):

--- a/tests/test_comm/test_loopback.py
+++ b/tests/test_comm/test_loopback.py
@@ -116,10 +116,16 @@ def test_loopbackcomm_read_raw_size_invalid():
         comm.read_raw(size=-2)
 
 
+@mock.patch("builtins.input")
+def test_loopbackcomm_read_raw_stdin(mock_input):
+    mock_input.return_value = "Returned string."
+    comm = LoopbackCommunicator()
+    assert comm.read_raw() == b"Returned string."
+
+
 def test_loopbackcomm_write_raw():
     mock_stdout = mock.MagicMock()
     comm = LoopbackCommunicator(stdout=mock_stdout)
-
     comm.write_raw(b"mock")
     mock_stdout.write.assert_called_with(b"mock")
 


### PR DESCRIPTION
I found a bug, that (at least under windows in cmd line and in ipython console) the loop-back without given input raises an error:
input() returns a string, while abstract_comm.read() expects an encoded byte array.

Corresponding to this change, also line 119 might be able to be deleted, as the last return will also return 118's input_var.

If you like, I could open an issue as well.