### PR TITLE
Fixes #354 bug that unitful_property with limits fails

### DIFF
--- a/src/instruments/util_fns.py
+++ b/src/instruments/util_fns.py
@@ -33,13 +33,14 @@ def assume_units(value, units):
         ``units``, depending on if ``value`` is unitful.
     :rtype: `Quantity`
     """
-    if isinstance(value, str):
+    if isinstance(value, u.Quantity):
+        return value
+    elif isinstance(value, str):
         value = u.Quantity(value)
         if value.dimensionless:
             return u.Quantity(value.magnitude, units)
-    elif not isinstance(value, u.Quantity):
-        return u.Quantity(value, units)
-    return value
+        return value
+    return u.Quantity(value, units)
 
 
 def setattr_expression(target, name_expr, value):
@@ -502,6 +503,8 @@ def unitful_property(
         if min_value is not None:
             if callable(min_value):
                 min_value = min_value(self)  # pylint: disable=not-callable
+            else:
+                min_value = assume_units(min_value, units)
             if newval < min_value:
                 raise ValueError(
                     f"Unitful quantity is too low. Got {newval}, "
@@ -510,6 +513,8 @@ def unitful_property(
         if max_value is not None:
             if callable(max_value):
                 max_value = max_value(self)  # pylint: disable=not-callable
+            else:
+                max_value = assume_units(max_value, units)
             if newval > max_value:
                 raise ValueError(
                     f"Unitful quantity is too high. Got {newval}, "

--- a/tests/test_property_factories/test_unitful_property.py
+++ b/tests/test_property_factories/test_unitful_property.py
@@ -127,10 +127,10 @@ def test_unitful_property_valid_range():
 def test_unitful_property_valid_range_functions():
     class UnitfulMock(MockInstrument):
         def min_value(self):
-            return 0
+            return 0 * u.Hz
 
         def max_value(self):
-            return 10
+            return 10 * u.Hz
 
         unitful_property = unitful_property(
             "MOCK", u.hertz, valid_range=(min_value, max_value)

--- a/tests/test_util_fns.py
+++ b/tests/test_util_fns.py
@@ -76,6 +76,10 @@ def mock_inst(mocker):
             "42", u.m, valid_range=(1 * u.m, 100 * u.m)
         )
 
+        unitful_property_limited_numbers = unitful_property(
+            "42", u.m, valid_range=(1, 100.)
+        )
+
         unitful_property = unitful_property("42", u.m)
 
         string_property = string_property("'STRING'")
@@ -191,7 +195,6 @@ def test_ProxyList_invalid_idx():
         (5 * u.mm, u.Quantity(5, "mm")),
         ("7.3 km", u.Quantity(7.3, "km")),
         (u.Quantity(9, "nm"), 9 * u.nm),
-        ([1, 5], u.Quantity([1, 5], u.m)),
     ),
 )
 def test_assume_units_correct(input, out):
@@ -322,7 +325,7 @@ class Test_unitful_property:
     @pytest.mark.parametrize("value", (0.1, 200, 0.1 * u.m, 200 * u.m))
     def test_unitful_property_sendcmd_limited_unfit(self, mock_inst, value):
         """Assert that unitful_property calls sendcmd, query of parent class.
-        Here an input out of bounds for limited property."""
+        Here an input out of bounds for quantity limited property."""
         # setter
         with pytest.raises(ValueError):
             mock_inst.unitful_property_limited = value
@@ -330,18 +333,44 @@ class Test_unitful_property:
     @pytest.mark.parametrize("value", (13 * u.m, 17 * u.m, 55 * u.m))
     def test_unitful_property_sendcmd_limited_pass_un(self, mock_inst, value):
         """Assert that unitful_property calls sendcmd, query of parent class.
-        Here an input fit for limited property."""
+        Here a quantity input fit for quantity limited property."""
         # setter
         mock_inst.unitful_property_limited = value
         assert mock_inst._sendcmd == f"42 {value.magnitude:e}"
         mock_inst.spy_sendcmd.assert_called()
 
-    @pytest.mark.parametrize("value", (13, 17, 55, 99))
+    @pytest.mark.parametrize("value", (13, 17., 55.5, 99))
     def test_unitful_property_sendcmd_limited_pass_ul(self, mock_inst, value):
         """Assert that unitful_property calls sendcmd, query of parent class.
-        Here an input fit for limited property."""
+        Here a numbers input fit for quantity limited property."""
         # setter
         mock_inst.unitful_property_limited = value
+        assert mock_inst._sendcmd == f"42 {value:e}"
+        mock_inst.spy_sendcmd.assert_called()
+
+    @pytest.mark.parametrize("value", (0.1, 200, 0.1 * u.m, 200 * u.m))
+    def test_unitful_property_sendcmd_limited_unfit2(self, mock_inst, value):
+        """Assert that unitful_property calls sendcmd, query of parent class.
+        Here an input out of numbered bounds for limited property."""
+        # setter
+        with pytest.raises(ValueError):
+            mock_inst.unitful_property_limited_numbers = value
+
+    @pytest.mark.parametrize("value", (13 * u.m, 17 * u.m, 55 * u.m))
+    def test_unitful_property_sendcmd_limited_pass_un2(self, mock_inst, value):
+        """Assert that unitful_property calls sendcmd, query of parent class.
+        Here a quantity input fit for numbers limited property."""
+        # setter
+        mock_inst.unitful_property_limited_numbers = value
+        assert mock_inst._sendcmd == f"42 {value.magnitude:e}"
+        mock_inst.spy_sendcmd.assert_called()
+
+    @pytest.mark.parametrize("value", (13, 17., 55.5, 99))
+    def test_unitful_property_sendcmd_limited_pass_ul2(self, mock_inst, value):
+        """Assert that unitful_property calls sendcmd, query of parent class.
+        Here a numbers input fit for numbers limited property."""
+        # setter
+        mock_inst.unitful_property_limited_numbers = value
         assert mock_inst._sendcmd == f"42 {value:e}"
         mock_inst.spy_sendcmd.assert_called()
 

--- a/tests/test_util_fns.py
+++ b/tests/test_util_fns.py
@@ -72,8 +72,9 @@ def mock_inst(mocker):
 
         int_property = int_property("42")
 
-        unitful_property_limited = unitful_property("42", u.m,
-                                                    valid_range=(1*u.m, 100*u.m))
+        unitful_property_limited = unitful_property(
+            "42", u.m, valid_range=(1 * u.m, 100 * u.m)
+        )
 
         unitful_property = unitful_property("42", u.m)
 
@@ -183,12 +184,16 @@ def test_ProxyList_invalid_idx():
         _ = proxy_list[10]  # Should raise IndexError
 
 
-@pytest.mark.parametrize("input, out", ((1, u.Quantity(1, "m")),
-                                        (5 * u.mm, u.Quantity(5, "mm")),
-                                        ("7.3 km", u.Quantity(7.3, "km")),
-                                        (u.Quantity(9, "nm"), 9 * u.nm),
-                                        ([1, 5], u.Quantity([1, 5], u.m)),
-                                        ))
+@pytest.mark.parametrize(
+    "input, out",
+    (
+        (1, u.Quantity(1, "m")),
+        (5 * u.mm, u.Quantity(5, "mm")),
+        ("7.3 km", u.Quantity(7.3, "km")),
+        (u.Quantity(9, "nm"), 9 * u.nm),
+        ([1, 5], u.Quantity([1, 5], u.m)),
+    ),
+)
 def test_assume_units_correct(input, out):
     unit_eq(assume_units(input, "m"), out)
 
@@ -314,7 +319,7 @@ class Test_unitful_property:
         assert mock_inst._sendcmd == f"42 {value:e}"
         mock_inst.spy_sendcmd.assert_called()
 
-    @pytest.mark.parametrize("value", (.1, 200, .1 * u.m, 200 * u.m))
+    @pytest.mark.parametrize("value", (0.1, 200, 0.1 * u.m, 200 * u.m))
     def test_unitful_property_sendcmd_limited_unfit(self, mock_inst, value):
         """Assert that unitful_property calls sendcmd, query of parent class.
         Here an input out of bounds for limited property."""


### PR DESCRIPTION
unitful_property did compare before assume_units was called, therefore a value without a unit did not pass the comparison, but raised an exception.

Assume_units accepts strings with units as well.