### PR TITLE
Rewrite SC10 shutter enable as toggle

### DIFF
--- a/src/instruments/thorlabs/sc10.py
+++ b/src/instruments/thorlabs/sc10.py
@@ -64,20 +64,27 @@ class SC10(Instrument):
         """
         return self.query("id?")
 
-    enable = bool_property(
-        "ens",
-        inst_true="1",
-        inst_false="0",
-        set_fmt="{}={}",
-        doc="""
+    @property
+    def enable(self):
+        """
         Gets/sets the shutter enable status, False for disabled, True if
         enabled
 
         If output enable is on (`True`), there is a voltage on the output.
-
+        :return: Status of the switch.
         :rtype: `bool`
-        """,
-    )
+
+        :raises TypeError: Unexpected type given when trying to enable.
+        """
+        return bool(int(self.query("ens?")))
+
+    @enable.setter
+    def enable(self, value):
+        if not isinstance(value, bool):
+            raise TypeError(f"Expected bool, got type {type(value)} instead.")
+        curr_status = self.enable
+        if curr_status != value:
+            self.sendcmd("ens")
 
     repeat = int_property(
         "rep",

--- a/src/instruments/thorlabs/sc10.py
+++ b/src/instruments/thorlabs/sc10.py
@@ -83,7 +83,7 @@ class SC10(Instrument):
         if not isinstance(value, bool):
             raise TypeError(f"Expected bool, got type {type(value)} instead.")
         curr_status = self.enable
-        if curr_status != value:
+        if curr_status is not value:
             self.sendcmd("ens")
 
     repeat = int_property(

--- a/tests/test_thorlabs/test_thorlabs_sc10.py
+++ b/tests/test_thorlabs/test_thorlabs_sc10.py
@@ -22,12 +22,25 @@ def test_sc10_name():
         assert sc.name == "bloopbloop"
 
 
-def test_sc10_enable():
+def test_sc10_enable_query():
     with expected_protocol(
-        ik.thorlabs.SC10, ["ens?", "ens=1"], ["ens?", "0", "> ens=1", "> "], sep="\r"
+        ik.thorlabs.SC10, ["ens?"], ["ens?", "0", "> "], sep="\r"
     ) as sc:
         assert sc.enable is False
-        sc.enable = True
+
+
+@pytest.mark.parametrize("status", [0, 1])
+@pytest.mark.parametrize("value", [0, 1])
+def test_sc10_enable_send(status, value):
+    host_to_ins = ["ens?"]
+    ins_to_host = ["ens?", f"{status}"]
+    if value != status:
+        host_to_ins.append("ens")
+        ins_to_host += ["> ens", "> "]
+    else:
+        ins_to_host.append("> ")
+    with expected_protocol(ik.thorlabs.SC10, host_to_ins, ins_to_host, sep="\r") as sc:
+        sc.enable = bool(value)
 
 
 def test_sc10_enable_invalid():


### PR DESCRIPTION
As discussed in #368, this PR rewrites the `sc.enable` routine for the Thorlabs SC10 shutter as a toggle. The toggle is implemented such that any setting of the property first queries the current status and then acts accordingly, i.e., toggle the status if necessary.
Tests are implemented for all cases. Existing get / set property test was split out into a get and set test. The latter now tests for cases, such that all cases are covered.