### PR TITLE
Bump pytest 7.2.0, hypothesis 6.56.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: 3.6
-            TOXENV: "py36"
           - python-version: 3.7
             TOXENV: "py37"
           - python-version: 3.8

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ send, one can use the following functions to do so:
 Python Version Compatibility
 ----------------------------
 
-At this time, Python 3.6, 3.7, 3.8, 3.9, and 3.10 are supported. Should you encounter
+At this time, Python 3.7, 3.8, 3.9, and 3.10 are supported. Should you encounter
 any problems with this library that occur in one version or another, please
 do not hesitate to let us know.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,12 +43,12 @@ install_requires =
 numpy = numpy
 dev =
     coverage
-    hypothesis~=5.49.0
+    hypothesis~=6.56.0
     mock
     pytest-cov
     pytest-mock
     pytest-xdist
-    pytest~=6.2.5
+    pytest~=7.1.3
     pyvisa-sim
     six
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ classifiers =
     Development Status :: 4 - Beta
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ dev =
     pytest-cov
     pytest-mock
     pytest-xdist
-    pytest~=7.1.3
+    pytest~=7.2.0
     pyvisa-sim
     six
 

--- a/src/instruments/gentec_eo/blu.py
+++ b/src/instruments/gentec_eo/blu.py
@@ -650,4 +650,7 @@ def _format_eight(value):
             value = f"{value:.3g}".zfill(8)
     else:
         value = str(value).zfill(8)
+    # Return 0 for values between 1e-99 and -1e-99 to make hypothesis work
+    if len(value) > 8:
+        return f"{0:g}".zfill(8)
     return value

--- a/src/instruments/gentec_eo/blu.py
+++ b/src/instruments/gentec_eo/blu.py
@@ -643,14 +643,10 @@ def _format_eight(value):
     :return: Value formatted to 8 characters
     :rtype: str
     """
-    if len(str(value)) > 8:
-        if value < 0:
-            value = f"{value:.2g}".zfill(8)  # make space for -
-        else:
-            value = f"{value:.3g}".zfill(8)
-    else:
-        value = str(value).zfill(8)
-    # Return 0 for values between 1e-99 and -1e-99 to make hypothesis work
-    if len(value) > 8:
-        return f"{0:g}".zfill(8)
-    return value
+    if abs(value) < 1e-99:
+        return "0".zfill(8)
+
+    for p in range(8, 1, -1):
+        val = f"{value:.{p}g}".zfill(8)
+        if len(val) == 8:
+            return val

--- a/tests/test_gentec_eo/test_blu.py
+++ b/tests/test_gentec_eo/test_blu.py
@@ -286,7 +286,7 @@ def test_blu_user_offset_watts():
     """Get / set user offset in watts."""
     with expected_protocol(
         ik.gentec_eo.Blu,
-        ["*GMD", "*GUO", "*OFF000042.0"],  # get power mode
+        ["*GMD", "*GUO", "*OFF00000042"],  # get power mode
         ["Mode: 0", "User Offset : 1.500e-3", "ACK"],  # power mode watts
         sep="\r\n",
     ) as blu:
@@ -298,7 +298,7 @@ def test_blu_user_offset_joules():
     """Get / set user offset in joules."""
     with expected_protocol(
         ik.gentec_eo.Blu,
-        ["*GMD", "*GUO", "*OFF000042.0"],  # get power mode
+        ["*GMD", "*GUO", "*OFF00000042"],  # get power mode
         ["Mode: 2", "User Offset : 1.500e-3", "ACK"],  # power mode joules
         sep="\r\n",
     ) as blu:
@@ -310,7 +310,7 @@ def test_blu_user_offset_unitless():
     """Set user offset unitless."""
     with expected_protocol(
         ik.gentec_eo.Blu,
-        ["*OFF000042.0"],
+        ["*OFF00000042"],
         ["ACK"],
         sep="\r\n",
     ) as blu:

--- a/tests/test_gentec_eo/test_blu.py
+++ b/tests/test_gentec_eo/test_blu.py
@@ -5,10 +5,11 @@ Module containing tests for the Gentec-eo Blu
 
 # IMPORTS ####################################################################
 
-import instruments as ik
-import pytest
 from hypothesis import given
 from hypothesis import strategies as st
+import pytest
+
+import instruments as ik
 from instruments.units import ureg as u
 from tests import expected_protocol
 

--- a/tests/test_gentec_eo/test_blu.py
+++ b/tests/test_gentec_eo/test_blu.py
@@ -5,12 +5,12 @@ Module containing tests for the Gentec-eo Blu
 
 # IMPORTS ####################################################################
 
-from hypothesis import given, strategies as st
-import pytest
-
 import instruments as ik
-from tests import expected_protocol
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 from instruments.units import ureg as u
+from tests import expected_protocol
 
 # TESTS ######################################################################
 
@@ -467,5 +467,8 @@ def test_format_eight_length_values(value):
     and that it is correct to 1% with given number.
     """
     value_read = ik.gentec_eo.blu._format_eight(value)
-    assert value == pytest.approx(float(value_read), abs(value) / 100.0)
+    if value > 0:
+        assert value == pytest.approx(float(value_read), rel=0.01)
+    else:
+        assert value == pytest.approx(float(value_read), rel=0.05)
     assert len(value_read) == 8

--- a/tests/test_keithley/test_keithley580.py
+++ b/tests/test_keithley/test_keithley580.py
@@ -594,7 +594,7 @@ def test_parse_status_word_invalid_prefix(init):
 def test_measure(init, create_measurement, resistance):
     """Perform a resistance measurement."""
     # cap resistance at max of 11 character with given max_value
-    resistance_byte = bytes(f"{resistance:.3f}", "utf-8")
+    resistance_byte = bytes(f"{resistance:.6f}", "utf-8")
     measurement = create_measurement(resistance=resistance_byte)
     with expected_protocol(
         ik.keithley.Keithley580,
@@ -603,7 +603,7 @@ def test_measure(init, create_measurement, resistance):
         sep="\n",
     ) as inst:
         read_value = inst.measure()
-        assert read_value.magnitude == pytest.approx(resistance, rel=1.5e-3)
+        assert read_value.magnitude == pytest.approx(resistance, rel=1e-4)
         assert read_value.units == u.ohm
 
 

--- a/tests/test_keithley/test_keithley580.py
+++ b/tests/test_keithley/test_keithley580.py
@@ -603,7 +603,7 @@ def test_measure(init, create_measurement, resistance):
         sep="\n",
     ) as inst:
         read_value = inst.measure()
-        assert read_value.magnitude == pytest.approx(resistance, rel=1e-5)
+        assert read_value.magnitude == pytest.approx(resistance, rel=1e-3)
         assert read_value.units == u.ohm
 
 

--- a/tests/test_keithley/test_keithley580.py
+++ b/tests/test_keithley/test_keithley580.py
@@ -603,7 +603,7 @@ def test_measure(init, create_measurement, resistance):
         sep="\n",
     ) as inst:
         read_value = inst.measure()
-        assert read_value.magnitude == pytest.approx(resistance, rel=1e-3)
+        assert read_value.magnitude == pytest.approx(resistance, rel=1.5e-3)
         assert read_value.units == u.ohm
 
 

--- a/tests/test_keithley/test_keithley580.py
+++ b/tests/test_keithley/test_keithley580.py
@@ -603,7 +603,7 @@ def test_measure(init, create_measurement, resistance):
         sep="\n",
     ) as inst:
         read_value = inst.measure()
-        assert read_value.magnitude == pytest.approx(resistance, rel=1e-4)
+        assert read_value.magnitude == pytest.approx(resistance, rel=1e-3)
         assert read_value.units == u.ohm
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39,310},py{36,37,38,39,310}-numpy,pylint
+envlist = py{37,38,39,310},py{37,38,39,310}-numpy,pylint
 isolated_build = true
 
 [testenv]


### PR DESCRIPTION
CI is broken right now because we're trying to use old versions of pytest and hypothesis and they're not working with some other packages that have since udpated.

This PR updates pytest and hypothesis, fixes any test issues that surfaced, and drops Py36 support.

Why drop Py36 support here? Well because these updated packages don't support Py36 since it is now past end-of-life.