### PR TITLE
Feat/close instruments

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     pyusb>=1.0
     pyvisa>=1.9
     ruamel.yaml>=0.16,<0.17
+    typing_extensions>=4.0.1
 
 [options.extras_require]
 numpy = numpy

--- a/src/instruments/abstract_instruments/comm/loopback_communicator.py
+++ b/src/instruments/abstract_instruments/comm/loopback_communicator.py
@@ -88,7 +88,8 @@ class LoopbackCommunicator(io.IOBase, AbstractCommunicator):
         Close connection to stdin
         """
         try:
-            self._stdin.close()
+            if self._stdin is not None:
+                self._stdin.close()
         except OSError:
             pass
 

--- a/src/instruments/abstract_instruments/instrument.py
+++ b/src/instruments/abstract_instruments/instrument.py
@@ -10,6 +10,7 @@ import os
 import collections
 import socket
 import struct
+import typing_extensions
 import urllib.parse as parse
 
 from serial import SerialException
@@ -718,3 +719,9 @@ class Instrument:
         :return: Object representing the connected instrument.
         """
         return cls(FileCommunicator(filename))
+
+    def __enter__(self) -> typing_extensions.Self:
+        return self
+
+    def __exit__(self, *exc):
+        self._file.__exit__(*exc)

--- a/tests/test_base_instrument.py
+++ b/tests/test_base_instrument.py
@@ -8,6 +8,8 @@ Module containing tests for the base Instrument class
 
 import socket
 import io
+import unittest
+from instruments.abstract_instruments import instrument
 import serial
 import usb.core
 from serial.tools.list_ports_common import ListPortInfo
@@ -482,6 +484,13 @@ def test_instrument_open_from_uri_vxi11(mock_open_conn):
 def test_instrument_open_from_uri_invalid_scheme():
     with pytest.raises(NotImplementedError):
         _ = ik.Instrument.open_from_uri("foo://bar")
+
+
+@mock.patch("instruments.abstract_instruments.comm.LoopbackCommunicator.close")
+def test_instrument_context_manager(mock_close: mock.Mock):
+    with ik.Instrument.open_test():
+        pass
+    mock_close.assert_called()
 
 
 # INIT TESTS

--- a/tests/test_base_instrument.py
+++ b/tests/test_base_instrument.py
@@ -8,8 +8,6 @@ Module containing tests for the base Instrument class
 
 import socket
 import io
-import unittest
-from instruments.abstract_instruments import instrument
 import serial
 import usb.core
 from serial.tools.list_ports_common import ListPortInfo


### PR DESCRIPTION
Allows for instruments to be used as context managers so you can do things like:

```python
with ik.Instrument.open_test() as instr:
        instr.do_something()
```

This way you can be confident your connection is being closed properly.