### PR TITLE
Add support for CPython 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,8 @@ jobs:
             TOXENV: "py39-numpy"
           - python-version: "3.10"
             TOXENV: "py310"
-
+          - python-version: "3.11"
+            TOXENV: "py311"
     steps:
     - uses: actions/checkout@v2
       with:

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ send, one can use the following functions to do so:
 Python Version Compatibility
 ----------------------------
 
-At this time, Python 3.7, 3.8, 3.9, and 3.10 are supported. Should you encounter
+At this time, Python 3.7, 3.8, 3.9, 3.10, and 3.11 are supported. Should you encounter
 any problems with this library that occur in one version or another, please
 do not hesitate to let us know.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Operating System :: OS Independent
     License :: OSI Approved :: GNU Affero General Public License v3
     Intended Audience :: Science/Research

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310},py{37,38,39,310}-numpy,pylint
+envlist = py{37,38,39,310,311},py{37,38,39,310,311}-numpy,pylint
 isolated_build = true
 
 [testenv]


### PR DESCRIPTION
CPython 3.11 is out, see https://www.python.org/downloads/release/python-3110/
Local tests seem to all run well, this PR adds support for 3.11.