### PR TITLE
Mettler Toledo Standard Interface Communication Software

### DIFF
--- a/doc/source/apiref/index.rst
+++ b/doc/source/apiref/index.rst
@@ -23,6 +23,7 @@ Contents:
     keithley
     lakeshore
     minghe
+    mettler_toledo
     newport
     ondax
     oxford

--- a/doc/source/apiref/mettler_toledo.rst
+++ b/doc/source/apiref/mettler_toledo.rst
@@ -1,0 +1,15 @@
+..
+    TODO: put documentation license header here.
+
+.. currentmodule:: instruments.mettler_toledo
+
+==============
+Mettler Toledo
+==============
+
+:class:`MTSICS` MT Standard Interface Communication Software
+============================================================
+
+.. autoclass:: MTSICS
+    :members:
+    :undoc-members:

--- a/src/instruments/__init__.py
+++ b/src/instruments/__init__.py
@@ -21,6 +21,7 @@ from . import holzworth
 from . import hp
 from . import keithley
 from . import lakeshore
+from . import mettler_toledo
 from . import minghe
 from . import newport
 from . import oxford

--- a/src/instruments/mettler_toledo/__init__.py
+++ b/src/instruments/mettler_toledo/__init__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+"""
+Module containing Mettler Toledo instruments
+"""
+
+from .mt_sics import MTSICS

--- a/src/instruments/mettler_toledo/mt_sics.py
+++ b/src/instruments/mettler_toledo/mt_sics.py
@@ -3,11 +3,11 @@
 Provides support for the Mettler Toledo balances via Standard Interface Command Set.
 """
 
-from enum import IntEnum, Enum
-
-from instruments.units import ureg as u
+import warnings
 
 from instruments.abstract_instruments import Instrument
+from instruments.units import ureg as u
+from instruments.util_fns import assume_units
 
 
 class MTSICS(Instrument):
@@ -26,9 +26,92 @@ class MTSICS(Instrument):
         super().__init__(filelike)
         self.terminator = "\r\n"
 
+    def clear_tare(self):
+        """
+        Clear the tare value.
+
+        Example usage:
+        >>> import instruments as ik
+        >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
+        >>> inst.clear_tare()
+        """
+        _ = self.query("TAC")
+
+    def reset(self):
+        """
+        Reset the balance.
+
+        Example usage:
+        >>> import instruments as ik
+        >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
+        >>> inst.reset()
+        """
+        _ = self.query("@")
+
+    def restart(self):
+        """
+        Restart the balance (warm restart).
+
+        Example usage:
+        >>> import instruments as ik
+        >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
+        >>> inst.restart()
+        """
+        _ = self.query("R01")
+
+    def tare(self):
+        """
+        Tare the balance after stable weight is obtained.
+
+        Example usage:
+        >>> import instruments as ik
+        >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
+        >>> inst.tare()
+        """
+        _ = self.query("T")
+
+    def tare_immediately(self):
+        """
+        Tare the balance immediately.
+
+        Example usage:
+        >>> import instruments as ik
+        >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
+        >>> inst.tare_immediately()
+        """
+        _ = self.query("TI")
+
+    def zero(self):
+        """
+        Zero the balance after stable weight is obtained.
+
+        Terminates processes such as zero, tare, calibration and testing etc.
+        If the device is in standby mode, it is turned on. This function sets the
+        currently read and the tare value to zero.
+
+        Example usage:
+        >>> import instruments as ik
+        >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
+        >>> inst.zero()
+        """
+        _ = self.query("Z")
+
+    def zero_immediately(self):
+        """
+        Zero the balance immediately.
+
+        Example usage:
+        >>> import instruments as ik
+        >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
+        >>> inst.zero_immediately()
+        """
+        _ = self.query("ZI")
+
     def query(self, cmd, size=-1):
         """
         Query the instrument for a response.
+
+        Error checking is performed on the response.
 
         :param str cmd: The command to send to the instrument.
         :param int size: Number of bytes to read from the instrument.
@@ -36,50 +119,104 @@ class MTSICS(Instrument):
         :return: The response from the instrument.
         :rtype: str
 
-        :raises: IOError
-            Command understood but cannot be executed at the moment.
-        :raises: IOError
-            Balance in over- or underrange mode.
+        :raises: UserWarning if the balance is in dynamic mode.
         """
         self.sendcmd(cmd)
 
         rval = self.read(size)
         rval = rval.split()
-        if rval[1] == "I":
-            raise OSError("Command understood but cannot be executed at the moment.")
-        elif rval[1] == "+":
-            raise OSError("Balance in overrange mode.")
-        elif rval[1] == "-":
-            raise OSError("Balance in underrange mode.")
-        return rval[1:]
 
-    def reset(self):
-        """
-        Reset the balance.
-        """
-        self.sendcmd("@")
+        # error checking
+        self._general_error_checking(rval[0])
+        self._cmd_error_checking(rval[1])
 
-    def zero(self):
-        """
-        Zero the balance.
-        """
-        self.sendcmd("Z")
+        # raise warning if balance in dynamic mode
+        if rval[1] == "D":
+            warnings.warn("Balance in dynamic mode.", UserWarning)
 
-    def zero_immediately(self):
+        return rval[2:]
+
+    def _cmd_error_checking(self, value):
         """
-        Zero the balance immediately.
+        Check for errors in the query response.
+
+        :param value: Command specific error code.
+        :return: None
+
+        :raises: OSError if an error in the command occurred.
         """
-        self.sendcmd("ZI")
+        if value == "I":
+            raise OSError("Internal error (e.g. balance not ready yet).")
+        elif value == "L":
+            raise OSError("Logical error (e.g. parameter not allowed).")
+        elif value == "+":
+            raise OSError(
+                "Weigh module or balance is in overload range"
+                "(weighing range exceeded)."
+            )
+        elif value == "-":
+            raise OSError(
+                "Weigh module or balance is in underload range"
+                "(e.g. weighing pan is not in place)."
+            )
+
+    def _general_error_checking(self, value):
+        """
+        Check for general errors in the query response.
+
+        :param value:  General error code.
+
+        :return: None
+
+        :raises: OSError if a general error occurred.
+        """
+        if value == "ES":
+            raise OSError("Syntax Error.")
+        elif value == "ET":
+            raise OSError("Transmission Error.")
+        elif value == "EL":
+            raise OSError("Logical Error.")
 
     @property
     def mt_sics(self):
         """
         Get MT-SICS level and MT-SICS versions.
 
-        :return: Level, Version Level 0, Version Level 1, Version Level 2, Version Level 3
+        :return: Level, Version Level 0, Version Level 1, Version Level 2,
+            Version Level 3
+
+        Example usage:
+        >>> import instruments as ik
+        >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
+        >>> inst.mt_sics
+        ['1', '1.0', '1.0', '1.0']
         """
-        retval = [it.replace('"', "") for it in self.query("I1")[1:]]
+        retval = [it.replace('"', "") for it in self.query("I1")]
         return retval
+
+    @property
+    def name(self):
+        """Get / Set balance name.
+
+        A maximum of 20 characters can be entered.
+
+        :raises ValueError: If name is longer than 20 characters.
+
+        Example usage:
+        >>> import instruments as ik
+        >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
+        >>> inst.name = "My Balance"
+        >>> inst.name
+        'My Balance'
+        """
+        retval = " ".join(self.query("I10"))
+        return retval.replace('"', "")
+
+    @name.setter
+    def name(self, value):
+        if len(value) > 20:
+            raise ValueError("Name must be 20 characters or less.")
+        _ = self.query(f'I10 "{value}"')
 
     @property
     def serial_number(self):
@@ -88,8 +225,36 @@ class MTSICS(Instrument):
 
         :return: The serial number of the balance.
         :rtype: str
+
+        Example usage:
+        >>> import instruments as ik
+        >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
+        >>> inst.serial_number
+        '123456789'
         """
-        return self.query("I4")[1].replace('"', "")
+        return self.query("I4")[0].replace('"', "")
+
+    @property
+    def tare_value(self):
+        """Get / set the tare value.
+
+        If no unit is given, grams are assumed.
+
+        Example usage:
+        >>> import instruments as ik
+        >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
+        >>> inst.tare_value = 1.0
+        >>> inst.tare_value
+        <Quantity(1.0, 'gram')>
+        """
+        retval = self.query("TA")
+        return u.Quantity(float(retval[0]), retval[1])
+
+    @tare_value.setter
+    def tare_value(self, value):
+        value = assume_units(value, u.gram)
+        value.to(u.gram)
+        _ = self.query(f"TA {value.magnitude} g")
 
     @property
     def weight(self):
@@ -98,9 +263,15 @@ class MTSICS(Instrument):
 
         :return: Stable weight
         :rtype: u.Quantity
+
+        Example usage:
+        >>> import instruments as ik
+        >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
+        >>> inst.weight
+        <Quantity(1.0, 'gram')>
         """
         retval = self.query("S")
-        return u.Quantity(float(retval[1]), retval[2])
+        return u.Quantity(float(retval[0]), retval[1])
 
     @property
     def weight_immediately(self):
@@ -109,6 +280,12 @@ class MTSICS(Instrument):
 
         :return: Immediate weight
         :rtype: u.Quantity
+
+        Example usage:
+        >>> import instruments as ik
+        >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
+        >>> inst.weight_immediately
+        <Quantity(1.0, 'gram')>
         """
         retval = self.query("SI")
-        return u.Quantity(float(retval[1]), retval[2])
+        return u.Quantity(float(retval[0]), retval[1])

--- a/src/instruments/mettler_toledo/mt_sics.py
+++ b/src/instruments/mettler_toledo/mt_sics.py
@@ -51,9 +51,12 @@ class MTSICS(Instrument):
         """
         _ = self.query("@")
 
-    def tare(self):
+    def tare(self, immediately=False):
         """
-        Tare the balance after stable weight is obtained.
+        Tare the balance.
+
+        :param bool immediately: Tare immediately if True, otherwise wait for stable
+            weight.
 
         Example usage:
 
@@ -61,21 +64,10 @@ class MTSICS(Instrument):
         >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
         >>> inst.tare()
         """
-        _ = self.query("T")
+        msg = "TI" if immediately else "T"
+        _ = self.query(msg)
 
-    def tare_immediately(self):
-        """
-        Tare the balance immediately.
-
-        Example usage:
-
-        >>> import instruments as ik
-        >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
-        >>> inst.tare_immediately()
-        """
-        _ = self.query("TI")
-
-    def zero(self):
+    def zero(self, immediately=False):
         """
         Zero the balance after stable weight is obtained.
 
@@ -83,25 +75,17 @@ class MTSICS(Instrument):
         If the device is in standby mode, it is turned on. This function sets the
         currently read and the tare value to zero.
 
+        :param bool immediately: Zero immediately if True, otherwise wait for stable
+            weight.
+
         Example usage:
 
         >>> import instruments as ik
         >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
         >>> inst.zero()
         """
-        _ = self.query("Z")
-
-    def zero_immediately(self):
-        """
-        Zero the balance immediately.
-
-        Example usage:
-
-        >>> import instruments as ik
-        >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
-        >>> inst.zero_immediately()
-        """
-        _ = self.query("ZI")
+        msg = "ZI" if immediately else "Z"
+        _ = self.query(msg)
 
     def query(self, cmd, size=-1):
         """

--- a/src/instruments/mettler_toledo/mt_sics.py
+++ b/src/instruments/mettler_toledo/mt_sics.py
@@ -16,6 +16,7 @@ class MTSICS(Instrument):
     Standared Interface Command Set.
 
     Example usage:
+
     >>> import instruments as ik
     >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
     >>> inst.weight_stable
@@ -31,6 +32,7 @@ class MTSICS(Instrument):
         Clear the tare value.
 
         Example usage:
+
         >>> import instruments as ik
         >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
         >>> inst.clear_tare()
@@ -42,6 +44,7 @@ class MTSICS(Instrument):
         Reset the balance.
 
         Example usage:
+
         >>> import instruments as ik
         >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
         >>> inst.reset()
@@ -53,6 +56,7 @@ class MTSICS(Instrument):
         Tare the balance after stable weight is obtained.
 
         Example usage:
+
         >>> import instruments as ik
         >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
         >>> inst.tare()
@@ -64,6 +68,7 @@ class MTSICS(Instrument):
         Tare the balance immediately.
 
         Example usage:
+
         >>> import instruments as ik
         >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
         >>> inst.tare_immediately()
@@ -79,6 +84,7 @@ class MTSICS(Instrument):
         currently read and the tare value to zero.
 
         Example usage:
+
         >>> import instruments as ik
         >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
         >>> inst.zero()
@@ -90,6 +96,7 @@ class MTSICS(Instrument):
         Zero the balance immediately.
 
         Example usage:
+
         >>> import instruments as ik
         >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
         >>> inst.zero_immediately()
@@ -175,6 +182,7 @@ class MTSICS(Instrument):
             Version Level 3
 
         Example usage:
+
         >>> import instruments as ik
         >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
         >>> inst.mt_sics
@@ -193,6 +201,13 @@ class MTSICS(Instrument):
 
         :return: List of all implemented MT-SICS levels and commands
         :rtype: list
+
+        Example usage:
+
+        >>> import instruments as ik
+        >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
+        >>> in inst.mt_sics_commands
+        [["0", "I0"], ["1", "D"]]
         """
         timeout = self.timeout
         self.timeout = u.Quantity(0.1, u.s)
@@ -220,6 +235,7 @@ class MTSICS(Instrument):
         :raises ValueError: If name is longer than 20 characters.
 
         Example usage:
+
         >>> import instruments as ik
         >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
         >>> inst.name = "My Balance"
@@ -244,6 +260,7 @@ class MTSICS(Instrument):
         :rtype: str
 
         Example usage:
+
         >>> import instruments as ik
         >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
         >>> inst.serial_number
@@ -258,6 +275,7 @@ class MTSICS(Instrument):
         If no unit is given, grams are assumed.
 
         Example usage:
+
         >>> import instruments as ik
         >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
         >>> inst.tare_value = 1.0
@@ -282,6 +300,7 @@ class MTSICS(Instrument):
         :rtype: u.Quantity
 
         Example usage:
+
         >>> import instruments as ik
         >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
         >>> inst.weight
@@ -299,6 +318,7 @@ class MTSICS(Instrument):
         :rtype: u.Quantity
 
         Example usage:
+
         >>> import instruments as ik
         >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
         >>> inst.weight_immediately

--- a/src/instruments/mettler_toledo/mt_sics.py
+++ b/src/instruments/mettler_toledo/mt_sics.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+"""
+Provides support for the Mettler Toledo balances via Standard Interface Command Set.
+"""
+
+from enum import IntEnum, Enum
+
+from instruments.units import ureg as u
+
+from instruments.abstract_instruments import Instrument
+
+
+class MTSICS(Instrument):
+    """
+    Instrument class to communicate with Mettler Toledo balances using the MT-SICS
+    Standared Interface Command Set.
+
+    Example usage:
+    >>> import instruments as ik
+    >>> inst = ik.mettler_toledo.MTSICS.open_serial('/dev/ttyUSB0', 9600)
+    >>> inst.weight_stable
+    <Quantity(120.2, 'gram')>
+    """
+
+    def __init__(self, filelike):
+        super().__init__(filelike)
+        self.terminator = "\r\n"
+
+    def query(self, cmd, size=-1):
+        """
+        Query the instrument for a response.
+
+        :param str cmd: The command to send to the instrument.
+        :param int size: Number of bytes to read from the instrument.
+
+        :return: The response from the instrument.
+        :rtype: str
+
+        :raises: IOError
+            Command understood but cannot be executed at the moment.
+        :raises: IOError
+            Balance in over- or underrange mode.
+        """
+        self.sendcmd(cmd)
+
+        rval = self.read(size)
+        rval = rval.split()
+        if rval[1] == "I":
+            raise OSError("Command understood but cannot be executed at the moment.")
+        elif rval[1] == "+":
+            raise OSError("Balance in overrange mode.")
+        elif rval[1] == "-":
+            raise OSError("Balance in underrange mode.")
+        return rval[1:]
+
+    def reset(self):
+        """
+        Reset the balance.
+        """
+        self.sendcmd("@")
+
+    def zero(self):
+        """
+        Zero the balance.
+        """
+        self.sendcmd("Z")
+
+    def zero_immediately(self):
+        """
+        Zero the balance immediately.
+        """
+        self.sendcmd("ZI")
+
+    @property
+    def mt_sics(self):
+        """
+        Get MT-SICS level and MT-SICS versions.
+
+        :return: Level, Version Level 0, Version Level 1, Version Level 2, Version Level 3
+        """
+        retval = [it.replace('"', "") for it in self.query("I1")[1:]]
+        return retval
+
+    @property
+    def serial_number(self):
+        """
+        Get the serial number of the balance.
+
+        :return: The serial number of the balance.
+        :rtype: str
+        """
+        return self.query("I4")[1].replace('"', "")
+
+    @property
+    def weight(self):
+        """
+        Get the stable weight.
+
+        :return: Stable weight
+        :rtype: u.Quantity
+        """
+        retval = self.query("S")
+        return u.Quantity(float(retval[1]), retval[2])
+
+    @property
+    def weight_immediately(self):
+        """
+        Get the weight immediately, irrespective of balance stability.
+
+        :return: Immediate weight
+        :rtype: u.Quantity
+        """
+        retval = self.query("SI")
+        return u.Quantity(float(retval[1]), retval[2])

--- a/tests/test_mettler_toledo/test_mt_sics.py
+++ b/tests/test_mettler_toledo/test_mt_sics.py
@@ -53,7 +53,7 @@ def test_zero():
         inst.zero()
 
 
-def test_zero_immidiately():
+def test_zero_immediately():
     """Zero the balance immediately."""
     with expected_protocol(ik.mettler_toledo.MTSICS, ["ZI"], ["ZI A"], "\r\n") as inst:
         inst.zero(immediately=True)

--- a/tests/test_mettler_toledo/test_mt_sics.py
+++ b/tests/test_mettler_toledo/test_mt_sics.py
@@ -44,7 +44,7 @@ def test_tare_immediately():
     with expected_protocol(
         ik.mettler_toledo.MTSICS, ["TI"], ["TI A 1.234 g"], "\r\n"
     ) as inst:
-        inst.tare_immediately()
+        inst.tare(immediately=True)
 
 
 def test_zero():
@@ -56,7 +56,7 @@ def test_zero():
 def test_zero_immidiately():
     """Zero the balance immediately."""
     with expected_protocol(ik.mettler_toledo.MTSICS, ["ZI"], ["ZI A"], "\r\n") as inst:
-        inst.zero_immediately()
+        inst.zero(immediately=True)
 
 
 @pytest.mark.parametrize("err", ["I", "L", "+", "-"])

--- a/tests/test_mettler_toledo/test_mt_sics.py
+++ b/tests/test_mettler_toledo/test_mt_sics.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+"""
+Tests for the Mettler Toledo Standard Interface Command Set (SICS).
+"""
+
+# IMPORTS #####################################################################
+
+import instruments as ik
+from tests import expected_protocol
+
+from instruments.units import ureg as u
+
+
+# TESTS #######################################################################
+
+
+def test_reset():
+    """Reset the balance."""
+    with expected_protocol(
+        ik.mettler_toledo.MTSICS, ["@"], ['@ A "123456789"'], "\r\n"
+    ) as inst:
+        inst.reset()
+
+
+def test_zero():
+    """Zero the balance."""
+    with expected_protocol(ik.mettler_toledo.MTSICS, ["Z"], ["Z A"], "\r\n") as inst:
+        inst.zero()
+
+
+def test_zero_immidiately():
+    """Zero the balance immediately."""
+    with expected_protocol(ik.mettler_toledo.MTSICS, ["ZI"], ["ZI A"], "\r\n") as inst:
+        inst.zero_immediately()
+
+
+# PROPERTIES #
+
+
+def test_mt_sics():
+    """Get MT-SICS level and MT-SICS versions."""
+    with expected_protocol(
+        ik.mettler_toledo.MTSICS, ["I1"], ["I1 A 01 2.00 2.00 2.00 1.0"], "\r\n"
+    ) as inst:
+        assert inst.mt_sics == ["01", "2.00", "2.00", "2.00", "1.0"]
+
+
+def test_serial_number():
+    """Get the serial number of the instrument."""
+    with expected_protocol(
+        ik.mettler_toledo.MTSICS, ["I4"], ["I4 A 0123456789"], "\r\n"
+    ) as inst:
+        assert inst.serial_number == "0123456789"
+
+
+def test_weight():
+    """Get the stable weight."""
+    with expected_protocol(
+        ik.mettler_toledo.MTSICS, ["S"], ["S A 1.234 g"], "\r\n"
+    ) as inst:
+        assert inst.weight == u.Quantity(1.234, u.gram)
+
+
+def test_weigth_immediately():
+    """Get the immediate weight."""
+    with expected_protocol(
+        ik.mettler_toledo.MTSICS, ["SI"], ["S D 1.234 g"], "\r\n"
+    ) as inst:
+        assert inst.weight_immediately == u.Quantity(1.234, u.gram)


### PR DESCRIPTION
Provide support for Mettler Toledo balances via their Standard Interface Communication Software. 

For manual, see [here](https://www.mt.com/ch/en/home/library/user-manuals/laboratory-weighing/RM-MT-SICS-MS-ML-ME.html).

This is a start of a new class for MT balances. Not all advanced functions are included, however, should be useful for the standard user that just needs to automate some weighting.