### PR TITLE
BF Yokogawa 6370, terminator setup for TCPIP

### DIFF
--- a/src/instruments/yokogawa/yokogawa6370.py
+++ b/src/instruments/yokogawa/yokogawa6370.py
@@ -8,6 +8,8 @@ Provides support for the Yokogawa 6370 optical spectrum analyzer.
 
 from enum import IntEnum, Enum
 
+import socket
+
 from instruments.units import ureg as u
 
 from instruments.abstract_instruments import OpticalSpectrumAnalyzer
@@ -37,6 +39,13 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        try:
+            if isinstance(self._file._conn, socket.socket):
+                self.terminator = "\r\n"  # TCP IP connection terminator
+        except AttributeError:  # not every connection has a _conn attribute
+            pass
+
         # Set data Format to binary
         self.sendcmd(":FORMat:DATA REAL,64")  # TODO: Find out where we want this
 

--- a/src/instruments/yokogawa/yokogawa6370.py
+++ b/src/instruments/yokogawa/yokogawa6370.py
@@ -30,6 +30,7 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
     """
     The Yokogawa 6370 is a optical spectrum analyzer.
     Example usage:
+
     >>> import instruments as ik
     >>> import instruments.units as u
     >>> inst = ik.yokogawa.Yokogawa6370.open_visa('TCPIP0:192.168.0.35')
@@ -171,9 +172,11 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
         """
         Gets the specific channel object.
         This channel is accessed as a list in the following manner::
+
         >>> import instruments as ik
         >>> osa = ik.yokogawa.Yokogawa6370.open_gpibusb('/dev/ttyUSB0')
         >>> dat = osa.channel["A"].data # Gets the data of channel 0
+
         :rtype: `list`[`~Yokogawa6370.Channel`]
         """
         return ProxyList(self, Yokogawa6370.Channel, Yokogawa6370.Traces)

--- a/src/instruments/yokogawa/yokogawa6370.py
+++ b/src/instruments/yokogawa/yokogawa6370.py
@@ -40,11 +40,8 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        try:
-            if isinstance(self._file, SocketCommunicator):
-                self.terminator = "\r\n"  # TCP IP connection terminator
-        except AttributeError:  # not every connection has a _conn attribute
-            pass
+        if isinstance(self._file, SocketCommunicator):
+            self.terminator = "\r\n"  # TCP IP connection terminator
 
         # Set data Format to binary
         self.sendcmd(":FORMat:DATA REAL,64")  # TODO: Find out where we want this

--- a/src/instruments/yokogawa/yokogawa6370.py
+++ b/src/instruments/yokogawa/yokogawa6370.py
@@ -8,11 +8,10 @@ Provides support for the Yokogawa 6370 optical spectrum analyzer.
 
 from enum import IntEnum, Enum
 
-import socket
-
 from instruments.units import ureg as u
 
 from instruments.abstract_instruments import OpticalSpectrumAnalyzer
+from instruments.abstract_instruments.comm import SocketCommunicator
 from instruments.util_fns import (
     enum_property,
     unitful_property,
@@ -41,7 +40,7 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
         super().__init__(*args, **kwargs)
 
         try:
-            if isinstance(self._file._conn, socket.socket):
+            if isinstance(self._file, SocketCommunicator):
                 self.terminator = "\r\n"  # TCP IP connection terminator
         except AttributeError:  # not every connection has a _conn attribute
             pass

--- a/tests/test_yokogawa/test_yokogawa_6370.py
+++ b/tests/test_yokogawa/test_yokogawa_6370.py
@@ -8,10 +8,12 @@ Unit tests for the Yokogawa 6370
 
 import struct
 
+from unittest import mock
 from hypothesis import (
     given,
     strategies as st,
 )
+import socket
 
 import instruments as ik
 from instruments.optional_dep_finder import numpy
@@ -21,6 +23,7 @@ from tests import (
     pytest,
 )
 from instruments.units import ureg as u
+from .. import mock
 
 
 # TESTS #######################################################################
@@ -43,6 +46,14 @@ def test_id():
         ["'YOKOGAWA,AQ6370D,x,02.08'"],
     ) as inst:
         assert inst.id == "YOKOGAWA,AQ6370D,x,02.08"
+
+
+@mock.patch("instruments.abstract_instruments.instrument.socket")
+def test_tcpip_connection_terminator(mock_socket):
+    """Ensure terminator is `\r\n` if connected via TCP-IP (issue #386)."""
+    mock_socket.socket.return_value.__class__ = socket.socket
+    inst = ik.yokogawa.Yokogawa6370.open_tcpip("127.0.0.1", port=1001)
+    assert inst.terminator == "\r\n"
 
 
 def test_status():

--- a/tests/test_yokogawa/test_yokogawa_6370.py
+++ b/tests/test_yokogawa/test_yokogawa_6370.py
@@ -8,7 +8,6 @@ Unit tests for the Yokogawa 6370
 
 import struct
 
-from unittest import mock
 from hypothesis import (
     given,
     strategies as st,


### PR DESCRIPTION
As discussed in #386, when connecting via TCP IP, the Yokogawa 6370 terminator is fixed to `"\r\n"`. This is now automatically set in the instrument when this type of connection is established. 