### PR TITLE
Add functionality to authenticate via TCPIP

### DIFF
--- a/src/instruments/abstract_instruments/comm/socket_communicator.py
+++ b/src/instruments/abstract_instruments/comm/socket_communicator.py
@@ -115,8 +115,6 @@ class SocketCommunicator(io.IOBase, AbstractCommunicator):
                         "a termination character."
                     )
                 result += c
-            # todo remove me
-            print(f"REC: {result}")
             return result[: -len(self._terminator)]
         else:
             raise ValueError("Must read a positive value of characters.")

--- a/src/instruments/abstract_instruments/comm/socket_communicator.py
+++ b/src/instruments/abstract_instruments/comm/socket_communicator.py
@@ -115,6 +115,8 @@ class SocketCommunicator(io.IOBase, AbstractCommunicator):
                         "a termination character."
                     )
                 result += c
+            # todo remove me
+            print(f"REC: {result}")
             return result[: -len(self._terminator)]
         else:
             raise ValueError("Must read a positive value of characters.")

--- a/src/instruments/abstract_instruments/instrument.py
+++ b/src/instruments/abstract_instruments/instrument.py
@@ -50,7 +50,7 @@ class Instrument:
     connections via the supported hardware channels.
     """
 
-    def __init__(self, filelike):
+    def __init__(self, filelike, *args, **kwargs):
         # Check to make sure filelike is a subclass of AbstractCommunicator
         if isinstance(filelike, AbstractCommunicator):
             self._file = filelike
@@ -63,6 +63,11 @@ class Instrument:
         # Record if we're using the Loopback Communicator and put class in
         # testing mode so we can disable sleeps in class implementations
         self._testing = isinstance(self._file, LoopbackCommunicator)
+
+        # Authenticate with `auth` (supplied as keyword argument) if provided
+        auth = kwargs.get("auth", None)
+        if auth is not None:
+            self._authenticate(auth)
 
         self._prompt = None
         self._terminator = "\n"
@@ -458,10 +463,7 @@ class Instrument:
         conn = socket.socket()
         conn.connect((host, port))
 
-        if auth:
-            cls._authenticate(cls, auth)
-
-        ret_cls = cls(SocketCommunicator(conn))
+        ret_cls = cls(SocketCommunicator(conn), auth=auth)
 
         return ret_cls
 

--- a/src/instruments/abstract_instruments/instrument.py
+++ b/src/instruments/abstract_instruments/instrument.py
@@ -64,11 +64,6 @@ class Instrument:
         # testing mode so we can disable sleeps in class implementations
         self._testing = isinstance(self._file, LoopbackCommunicator)
 
-        # Authenticate with `auth` (supplied as keyword argument) if provided
-        auth = kwargs.get("auth", None)
-        if auth is not None:
-            self._authenticate(auth)
-
         self._prompt = None
         self._terminator = "\n"
 

--- a/src/instruments/abstract_instruments/instrument.py
+++ b/src/instruments/abstract_instruments/instrument.py
@@ -72,6 +72,18 @@ class Instrument:
     def _ack_expected(self, msg=""):  # pylint: disable=unused-argument,no-self-use
         return None
 
+    def _authenticate(self, username, password):
+        """
+        Authenticate with username, password for establishing the communication
+        with the instrument.
+
+        :param username: Username
+        :type username: str
+        :param password: Password
+        :type username: str
+        """
+        raise NotImplementedError
+
     def sendcmd(self, cmd):
         """
         Sends a command without waiting for a response.
@@ -430,12 +442,14 @@ class Instrument:
             raise NotImplementedError("Invalid scheme or not yet " "implemented.")
 
     @classmethod
-    def open_tcpip(cls, host, port):
+    def open_tcpip(cls, host, port, username=None, password=""):
         """
         Opens an instrument, connecting via TCP/IP to a given host and TCP port.
 
         :param str host: Name or IP address of the instrument.
         :param int port: TCP port on which the insturment is listening.
+        :param str username: Username for the instrument, if required.
+        :param str password: Password for the instrument, if required.
 
         :rtype: `Instrument`
         :return: Object representing the connected instrument.
@@ -446,7 +460,13 @@ class Instrument:
         """
         conn = socket.socket()
         conn.connect((host, port))
-        return cls(SocketCommunicator(conn))
+
+        if username:
+            cls._authenticate(cls, username, password)
+
+        ret_cls = cls(SocketCommunicator(conn))
+
+        return ret_cls
 
     # pylint: disable=too-many-arguments
     @classmethod

--- a/src/instruments/abstract_instruments/instrument.py
+++ b/src/instruments/abstract_instruments/instrument.py
@@ -72,15 +72,12 @@ class Instrument:
     def _ack_expected(self, msg=""):  # pylint: disable=unused-argument,no-self-use
         return None
 
-    def _authenticate(self, username, password):
+    def _authenticate(self, auth):
         """
-        Authenticate with username, password for establishing the communication
-        with the instrument.
+        Authenticate with credentials for establishing the communication with the
+        instrument.
 
-        :param username: Username
-        :type username: str
-        :param password: Password
-        :type username: str
+        :param auth: Credentials for authentication.
         """
         raise NotImplementedError
 
@@ -442,14 +439,14 @@ class Instrument:
             raise NotImplementedError("Invalid scheme or not yet " "implemented.")
 
     @classmethod
-    def open_tcpip(cls, host, port, username=None, password=""):
+    def open_tcpip(cls, host, port, auth=None):
         """
         Opens an instrument, connecting via TCP/IP to a given host and TCP port.
 
         :param str host: Name or IP address of the instrument.
         :param int port: TCP port on which the insturment is listening.
-        :param str username: Username for the instrument, if required.
-        :param str password: Password for the instrument, if required.
+        :param auth: Authentication credentials to establish connection.
+            Type depends on instrument and authentication method used.
 
         :rtype: `Instrument`
         :return: Object representing the connected instrument.
@@ -461,8 +458,8 @@ class Instrument:
         conn = socket.socket()
         conn.connect((host, port))
 
-        if username:
-            cls._authenticate(cls, username, password)
+        if auth:
+            cls._authenticate(cls, auth)
 
         ret_cls = cls(SocketCommunicator(conn))
 

--- a/src/instruments/yokogawa/yokogawa6370.py
+++ b/src/instruments/yokogawa/yokogawa6370.py
@@ -320,3 +320,10 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
     def clear(self):
         """Clear status registers."""
         self.sendcmd("*CLS")
+
+    def query(self, cmd, size=-1):
+        """todo: remove"""
+        print(f"CMD: {cmd}")
+        retval = super().query(cmd, size=size)
+        print(f"RESP: {retval}")
+        return retval

--- a/src/instruments/yokogawa/yokogawa6370.py
+++ b/src/instruments/yokogawa/yokogawa6370.py
@@ -66,16 +66,7 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
         """
         username, password = auth
         _ = self.query(f'OPEN "{username}"')
-        resp = self.query(
-            '"AUTHENTICATE CRAM-MD5 OK"'
-        )  # if anonymous, this is the password, and it should return "ready"
-
-        # hash it
-        if username.lower() != "anonymous":  # so we need an actual password
-            pwd = hashlib.md5()
-            pwd.update(bytes(resp, "utf-8"))
-            pwd.update(bytes(password, "utf-8"))
-            resp = self.query(pwd.hexdigest())
+        resp = self.query(f'"{password}"')
 
         if "ready" not in resp.lower():
             raise ConnectionError("Could not authenticate with username / password")

--- a/src/instruments/yokogawa/yokogawa6370.py
+++ b/src/instruments/yokogawa/yokogawa6370.py
@@ -43,6 +43,11 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
         if isinstance(self._file, SocketCommunicator):
             self.terminator = "\r\n"  # TCP IP connection terminator
 
+        # Authenticate with `auth` (supplied as keyword argument) if provided
+        auth = kwargs.get("auth", None)
+        if auth is not None:
+            self._authenticate(auth)
+
         # Set data Format to binary
         self.sendcmd(":FORMat:DATA REAL,64")  # TODO: Find out where we want this
 

--- a/src/instruments/yokogawa/yokogawa6370.py
+++ b/src/instruments/yokogawa/yokogawa6370.py
@@ -66,12 +66,17 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
         """
         username, password = auth
         _ = self.query(f'OPEN "{username}"')
-        resp = self.query("AUTHENTICATE CRAM-MD5 OK")
+        resp = self.query(
+            "AUTHENTICATE CRAM-MD5 OK"
+        )  # if anonymous, this is the password, and it should return "ready"
+
         # hash it
-        pwd = hashlib.md5()
-        pwd.update(bytes(resp, "utf-8"))
-        pwd.update(bytes(password, "utf-8"))
-        resp = self.query(pwd.hexdigest())
+        if username.lower() != "anonymous":  # so we need an actual password
+            pwd = hashlib.md5()
+            pwd.update(bytes(resp, "utf-8"))
+            pwd.update(bytes(password, "utf-8"))
+            resp = self.query(pwd.hexdigest())
+
         if "ready" not in resp.lower():
             raise ConnectionError("Could not authenticate with username / password")
 

--- a/src/instruments/yokogawa/yokogawa6370.py
+++ b/src/instruments/yokogawa/yokogawa6370.py
@@ -46,8 +46,12 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
         # Set data Format to binary
         self.sendcmd(":FORMat:DATA REAL,64")  # TODO: Find out where we want this
 
-    def _authenticate(self, username, password):
-        # authenticate username, password are set
+    def _authenticate(self, auth):
+        """Authenticate with the instrument.
+
+        :param auth: Authentication tuple of (username, password)
+        """
+        username, password = auth
         _ = self.query(f'open "{username}"')
         resp = self.query(password)
         if "ready" not in resp.lower():

--- a/src/instruments/yokogawa/yokogawa6370.py
+++ b/src/instruments/yokogawa/yokogawa6370.py
@@ -67,7 +67,7 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
         username, password = auth
         _ = self.query(f'OPEN "{username}"')
         resp = self.query(
-            "AUTHENTICATE CRAM-MD5 OK"
+            '"AUTHENTICATE CRAM-MD5 OK"'
         )  # if anonymous, this is the password, and it should return "ready"
 
         # hash it

--- a/src/instruments/yokogawa/yokogawa6370.py
+++ b/src/instruments/yokogawa/yokogawa6370.py
@@ -46,6 +46,13 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
         # Set data Format to binary
         self.sendcmd(":FORMat:DATA REAL,64")  # TODO: Find out where we want this
 
+    def _authenticate(self, username, password):
+        # authenticate username, password are set
+        _ = self.query(f'open "{username}"')
+        resp = self.query(password)
+        if "ready" not in resp.lower():
+            raise ConnectionError("Could not authenticate with username / password")
+
     # INNER CLASSES #
 
     class Channel(OpticalSpectrumAnalyzer.Channel):

--- a/src/instruments/yokogawa/yokogawa6370.py
+++ b/src/instruments/yokogawa/yokogawa6370.py
@@ -52,7 +52,7 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
         :param auth: Authentication tuple of (username, password)
         """
         username, password = auth
-        _ = self.query(f'open "{username}"')
+        _ = self.query(f'OPEN "{username}"')
         resp = self.query(password)
         if "ready" not in resp.lower():
             raise ConnectionError("Could not authenticate with username / password")

--- a/tests/test_base_instrument.py
+++ b/tests/test_base_instrument.py
@@ -113,14 +113,11 @@ def test_instrument_open_tcpip(mock_socket, mock_socket_comm):
     mock_socket_comm.assert_called_with(mock_socket.socket.return_value)
 
 
-@mock.patch("instruments.abstract_instruments.instrument.SocketCommunicator")
-@mock.patch("instruments.abstract_instruments.instrument.socket")
-def test_instrument_open_tcpip_auth_not_implemented(mock_socket, mock_socket_comm):
-    mock_socket.socket.return_value.__class__ = socket.socket
-    mock_socket_comm.return_value.__class__ = SocketCommunicator
-
+def test_instrument_open_tcpip_auth_not_implemented():  # mock_socket, mock_socket_comm):
+    """Ensure `_authenticate` raises NotImplementedError if not implemented."""
+    inst = ik.Instrument.open_test()
     with pytest.raises(NotImplementedError):
-        _ = ik.Instrument.open_tcpip("127.0.0.1", 1234, auth=("user", "pwd"))
+        inst._authenticate(auth=("user", "pwd"))
 
 
 @mock.patch("instruments.abstract_instruments.instrument.serial_manager")

--- a/tests/test_base_instrument.py
+++ b/tests/test_base_instrument.py
@@ -113,6 +113,16 @@ def test_instrument_open_tcpip(mock_socket, mock_socket_comm):
     mock_socket_comm.assert_called_with(mock_socket.socket.return_value)
 
 
+@mock.patch("instruments.abstract_instruments.instrument.SocketCommunicator")
+@mock.patch("instruments.abstract_instruments.instrument.socket")
+def test_instrument_open_tcpip_auth_not_implemented(mock_socket, mock_socket_comm):
+    mock_socket.socket.return_value.__class__ = socket.socket
+    mock_socket_comm.return_value.__class__ = SocketCommunicator
+
+    with pytest.raises(NotImplementedError):
+        _ = ik.Instrument.open_tcpip("127.0.0.1", 1234, username="user", password="pwd")
+
+
 @mock.patch("instruments.abstract_instruments.instrument.serial_manager")
 def test_instrument_open_serial(mock_serial_manager):
     mock_serial_manager.new_serial_connection.return_value.__class__ = (

--- a/tests/test_base_instrument.py
+++ b/tests/test_base_instrument.py
@@ -120,7 +120,7 @@ def test_instrument_open_tcpip_auth_not_implemented(mock_socket, mock_socket_com
     mock_socket_comm.return_value.__class__ = SocketCommunicator
 
     with pytest.raises(NotImplementedError):
-        _ = ik.Instrument.open_tcpip("127.0.0.1", 1234, username="user", password="pwd")
+        _ = ik.Instrument.open_tcpip("127.0.0.1", 1234, auth=("user", "pwd"))
 
 
 @mock.patch("instruments.abstract_instruments.instrument.serial_manager")

--- a/tests/test_base_instrument.py
+++ b/tests/test_base_instrument.py
@@ -113,8 +113,8 @@ def test_instrument_open_tcpip(mock_socket, mock_socket_comm):
     mock_socket_comm.assert_called_with(mock_socket.socket.return_value)
 
 
-def test_instrument_open_tcpip_auth_not_implemented():  # mock_socket, mock_socket_comm):
-    """Ensure `_authenticate` raises NotImplementedError if not implemented."""
+def test_instrument_open_tcpip_auth_not_implemented():
+    """Ensure `_authenticate` exists and raises NotImplemented error if hit here."""
     inst = ik.Instrument.open_test()
     with pytest.raises(NotImplementedError):
         inst._authenticate(auth=("user", "pwd"))

--- a/tests/test_yokogawa/test_yokogawa_6370.py
+++ b/tests/test_yokogawa/test_yokogawa_6370.py
@@ -80,15 +80,13 @@ def test_tcpip_authentication(mock_socket, mocker):
         "127.0.0.1", 1234, auth=(username, password)
     )
 
-    pwd = hashlib.md5(bytes(f"ready{password}", "utf-8")).hexdigest()
     calls = [
         mocker.call(f'OPEN "{username}"'),
-        mocker.call('"AUTHENTICATE CRAM-MD5 OK"'),
-        mocker.call(f"{pwd}"),
+        mocker.call(f'"{password}"'),
     ]
     mock_query.assert_has_calls(calls, any_order=False)
 
-    assert call_order == [mock_query, mock_query, mock_query, mock_sendcmd]
+    assert call_order == [mock_query, mock_query, mock_sendcmd]
 
 
 @mock.patch("instruments.abstract_instruments.instrument.socket")
@@ -116,12 +114,9 @@ def test_tcpip_authentication_anonymous(mock_socket, mocker):
         "127.0.0.1", 1234, auth=(username, password)
     )
 
-    pwd = hashlib.md5(bytes(f"ready{password}", "utf-8")).hexdigest()
     calls = [
         mocker.call(f'OPEN "{username}"'),
-        mocker.call(
-            '"AUTHENTICATE CRAM-MD5 OK"'
-        ),  # this is the password since any is accepted
+        mocker.call(f'"{password}"'),  # this is the password since any is accepted
     ]
     mock_query.assert_has_calls(calls, any_order=False)
 

--- a/tests/test_yokogawa/test_yokogawa_6370.py
+++ b/tests/test_yokogawa/test_yokogawa_6370.py
@@ -77,7 +77,7 @@ def test_tcpip_authentication(mock_socket, mocker):
     password = "my_password"
 
     _ = ik.yokogawa.Yokogawa6370.open_tcpip(
-        "127.0.0.1", 1234, username=username, password=password
+        "127.0.0.1", 1234, auth=(username, password)
     )
 
     calls = [mocker.call(f'open "{username}"'), mocker.call(f"{password}")]
@@ -99,7 +99,7 @@ def test_tcpip_authentication_error(mock_socket, mocker):
 
     with pytest.raises(ConnectionError):
         _ = ik.yokogawa.Yokogawa6370.open_tcpip(
-            "127.0.0.1", 1234, username=username, password=password
+            "127.0.0.1", 1234, auth=(username, password)
         )
 
 

--- a/tests/test_yokogawa/test_yokogawa_6370.py
+++ b/tests/test_yokogawa/test_yokogawa_6370.py
@@ -80,7 +80,7 @@ def test_tcpip_authentication(mock_socket, mocker):
         "127.0.0.1", 1234, auth=(username, password)
     )
 
-    calls = [mocker.call(f'open "{username}"'), mocker.call(f"{password}")]
+    calls = [mocker.call(f'OPEN "{username}"'), mocker.call(f"{password}")]
     mock_query.assert_has_calls(calls, any_order=False)
 
     assert call_order == [mock_query, mock_query, mock_sendcmd]

--- a/tests/test_yokogawa/test_yokogawa_6370.py
+++ b/tests/test_yokogawa/test_yokogawa_6370.py
@@ -83,7 +83,7 @@ def test_tcpip_authentication(mock_socket, mocker):
     pwd = hashlib.md5(bytes(f"ready{password}", "utf-8")).hexdigest()
     calls = [
         mocker.call(f'OPEN "{username}"'),
-        mocker.call("AUTHENTICATE CRAM-MD5 OK"),
+        mocker.call('"AUTHENTICATE CRAM-MD5 OK"'),
         mocker.call(f"{pwd}"),
     ]
     mock_query.assert_has_calls(calls, any_order=False)
@@ -120,7 +120,7 @@ def test_tcpip_authentication_anonymous(mock_socket, mocker):
     calls = [
         mocker.call(f'OPEN "{username}"'),
         mocker.call(
-            "AUTHENTICATE CRAM-MD5 OK"
+            '"AUTHENTICATE CRAM-MD5 OK"'
         ),  # this is the password since any is accepted
     ]
     mock_query.assert_has_calls(calls, any_order=False)


### PR DESCRIPTION
This was first mentioned in #386. The Yokogawa 6370 authentication via TCPIP can go with username, password, or with anonymous user identification, where the username `anonymous` is sent and any password is valid.

I added a private `_authenticate` routine to `instrument` and to the Yokogawa itself (where it is actually implemented). The authentication will likely be slightly different for different instruments, therefore it is specific to the instrument.
@slagroommarino it would be great if you can test this with the actual instrument!

The one thing that might be iffy: the password authentication is in plain text. While the instrument accepts MD5 hashing, the way it would have to be implemented requires user interaction, see [manual](https://cdn.tmi.yokogawa.com/1/6057/files/IMAQ6370C-17EN.pdf) page 3-8. Instead of a password, a challenge string is requested after sending the username, that challenge string together with the password would have to be MD5 hashed (`hashlib` could be used), and then sent back to the instrument. The password is not stored in `ik`, however, even disassociated will remain in memory. This is hard to get rid off I think without an actual user interaction.

What we could do, instead of sending the password in plain text via TCPIP is to do the MD5 hashing in `ik`, in this case inside the `_authenticate` in the instrument. What do you think @scasagrande? The manual is unfortunately not very clear on how things are hashed together, my best guess would be the following routine inside the instrument (and `import hashlib`) at the start:

```python
    def _authenticate(self, username, password):
        # authenticate username, password are set
        _ = self.query(f'open "{username}"')
        resp = self.query("AUTHENTICATE CRAM-MD5 OK")
        # hash it
        pwd = hashlib.md5()
        pwd.update(resp)
        pwd.update(password)
        resp = self.query(pwd.hexdigest())
        if "ready" not in resp.lower():
            raise ConnectionError("Could not authenticate with username / password")
```

However, since the manual is not very clear, I wonder if @slagroommarino could test this before implementation.

With the discussion, I mark this as a draft PR for now.