### PR TITLE
Pin pint to >=0.16.1,<0.21.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ package_dir =
     = src
 packages = find:
 install_requires =
-    pint>=0.16.1
+    pint>=0.16.1,<0.21.0
     pyserial>=3.3
     python-usbtmc
     python-vxi11>=0.8


### PR DESCRIPTION
As discussed in #395, pinning the pint version to `>=0.16.1,<0.21.0`. This should fix the current testing issue, but needs revisiting when we drop `py37` support.