### PR TITLE
CPython 3.12 support, drop 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: 3.7
-            TOXENV: "py37"
           - python-version: 3.8
             TOXENV: "py38"
           - python-version: 3.9
@@ -35,6 +33,8 @@ jobs:
             TOXENV: "py310"
           - python-version: "3.11"
             TOXENV: "py311"
+          - python-version: "3.12"
+            TOXENV: "py312"
     steps:
     - uses: actions/checkout@v2
       with:

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ send, one can use the following functions to do so:
 Python Version Compatibility
 ----------------------------
 
-At this time, Python 3.7, 3.8, 3.9, 3.10, and 3.11 are supported. Should you encounter
+At this time, Python  3.8, 3.9, 3.10, 3.11, and 3.12 are supported. Should you encounter
 any problems with this library that occur in one version or another, please
 do not hesitate to let us know.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,11 +12,11 @@ classifiers =
     Development Status :: 4 - Beta
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Operating System :: OS Independent
     License :: OSI Approved :: GNU Affero General Public License v3
     Intended Audience :: Science/Research

--- a/tests/test_newport/test_newportesp301.py
+++ b/tests/test_newport/test_newportesp301.py
@@ -191,7 +191,7 @@ def test_define_program(prg_id):
                 mock.call("EP", target=prg_id),
                 mock.call("QP"),
             )
-            mock_cmd.has_calls(calls)
+            mock_cmd.assert_has_calls(calls)
 
 
 @given(prg_id=st.integers().filter(lambda x: x < 1 or x > 100))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311},py{37,38,39,310,311}-numpy,pylint
+envlist = py{38,39,310,311,312},py{38,39,310,311,312}-numpy,pylint
 isolated_build = true
 
 [testenv]


### PR DESCRIPTION
Add support and testing for py3.12, drop 3.7 since EOL. Change a test to `assert_has_calls`, since `has_calls` seems to be depreciated in 3.12.

Note: There are a few more depreciation warnings that need to be taken care of. However, this should be fixed in a separate PR.