### PR TITLE
Update ruamel.yaml to >=0.18

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     python-vxi11>=0.8
     pyusb>=1.0
     pyvisa>=1.9
-    ruamel.yaml>=0.16,<0.17
+    ruamel.yaml>=0.18
     typing_extensions>=4.0.1
 
 [options.extras_require]

--- a/src/instruments/config.py
+++ b/src/instruments/config.py
@@ -8,17 +8,7 @@ Module containing support for loading instruments from configuration files.
 
 import warnings
 
-try:
-    import ruamel.yaml as yaml
-except ImportError:
-    # Some versions of ruamel.yaml are named ruamel_yaml, so try that
-    # too.
-    #
-    # In either case, we've observed issues with pylint where it will raise
-    # a false positive from its import-error checker, so we locally disable
-    # it here. Once the cause for the false positive has been identified,
-    # the import-error check should be re-enabled.
-    import ruamel_yaml as yaml  # pylint: disable=import-error
+from ruamel.yaml import YAML
 
 from instruments.units import ureg as u
 from instruments.util_fns import setattr_expression, split_unit_str
@@ -67,7 +57,8 @@ def quantity_constructor(loader, node):
 
 # We avoid having to register !Q every time by doing as soon as the
 # relevant constructor is defined.
-yaml.add_constructor("!Q", quantity_constructor)
+yaml = YAML(typ="unsafe")
+yaml.Constructor.add_constructor("!Q", quantity_constructor)
 
 
 def load_instruments(conf_file_name, conf_path="/"):
@@ -139,16 +130,11 @@ def load_instruments(conf_file_name, conf_path="/"):
         such processing will occur independently of the value of ``conf_path``.
     """
 
-    if yaml is None:
-        raise ImportError(
-            "Could not import ruamel.yaml, which is required " "for this function."
-        )
-
     if isinstance(conf_file_name, str):
         with open(conf_file_name) as f:
-            conf_dict = yaml.load(f, Loader=yaml.Loader)
+            conf_dict = yaml.load(f)
     else:
-        conf_dict = yaml.load(conf_file_name, Loader=yaml.Loader)
+        conf_dict = yaml.load(conf_file_name)
 
     conf_dict = walk_dict(conf_dict, conf_path)
 

--- a/src/instruments/config.py
+++ b/src/instruments/config.py
@@ -55,9 +55,9 @@ def quantity_constructor(loader, node):
     return u.Quantity(*split_unit_str(value))
 
 
+yaml = YAML(typ="unsafe")
 # We avoid having to register !Q every time by doing as soon as the
 # relevant constructor is defined.
-yaml = YAML(typ="unsafe")
 yaml.Constructor.add_constructor("!Q", quantity_constructor)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,8 +8,11 @@ Module containing tests for util_fns.py
 
 from io import StringIO
 
+import pytest
+
 from instruments.units import ureg as u
 
+import instruments as ik
 from instruments import Instrument
 from instruments.config import load_instruments, yaml
 
@@ -27,6 +30,20 @@ test:
 """
     )
     insts = load_instruments(config_data)
+    assert isinstance(insts["test"], Instrument)
+
+
+def test_load_test_instrument_from_file(tmp_path):
+    """Load an instrument from a `.yml` file with filename as string."""
+    conf_file = tmp_path.joinpath("config.yml")
+    conf_file.write_text(
+        """
+test:
+    class: !!python/name:instruments.Instrument
+    uri: test://
+"""
+    )
+    insts = load_instruments(str(conf_file.absolute()))
     assert isinstance(insts["test"], Instrument)
 
 
@@ -70,3 +87,19 @@ test:
     )
     insts = load_instruments(config_data)
     assert insts["test"].foo == u.Quantity(111, "GHz")
+
+
+def test_load_test_instrument_oserror(mocker):
+    """Raise warning and continue in case loading test instrument fails with OSError."""
+    config_data = StringIO(
+        """
+test:
+    class: !!python/name:instruments.Instrument
+    uri: test://
+"""
+    )
+
+    mocker.patch.object(Instrument, "open_from_uri", side_effect=OSError)
+
+    with pytest.warns(RuntimeWarning):
+        _ = load_instruments(config_data)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -52,7 +52,7 @@ a:
     d: !Q 98
 """
     )
-    data = yaml.load(yaml_data, Loader=yaml.Loader)
+    data = yaml.load(yaml_data)
     assert data["a"]["b"] == u.Quantity(37, "tesla")
     assert data["a"]["c"] == u.Quantity(41.2, "inches")
     assert data["a"]["d"] == 98


### PR DESCRIPTION
Part of #406 

- Fix configuration to use the new style
- Fix test where old loader was called

Currently I'm using the `unsafe` loader, which would be okay since the docs specify that this is not safe for files you don't trust. 

However, we could try and register all `ik` classes with the yaml loader, [see here](https://yaml.readthedocs.io/en/latest/dumpcls/). Scratching my head at the moment though why I can't even get the tests to run when I register `instruments.Instrument` with 

```python
from instruments.config import yaml

@yaml.register_class
class Instrument
    ...
```

Any ideas?