### PR TITLE
Updgrade pint dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ package_dir =
     = src
 packages = find:
 install_requires =
-    pint~=0.21.0
+    pint>=0.21.0
     pyserial>=3.3
     python-usbtmc
     python-vxi11>=0.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ package_dir =
     = src
 packages = find:
 install_requires =
-    pint>=0.23.0
+    pint~=0.21.0
     pyserial>=3.3
     python-usbtmc
     python-vxi11>=0.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ package_dir =
     = src
 packages = find:
 install_requires =
-    pint>=0.16.1,<0.21.0
+    pint>=0.23.0
     pyserial>=3.3
     python-usbtmc
     python-vxi11>=0.8

--- a/src/instruments/units.py
+++ b/src/instruments/units.py
@@ -10,5 +10,4 @@ import pint
 # UNITS #######################################################################
 
 ureg = pint.get_application_registry()
-ureg.define("percent = []")
 ureg.define("centibelmilliwatt = 1e-3 watt; logbase: 10; logfactor: 100 = cBm")


### PR DESCRIPTION
Upgrade `pint` dependency to remove the in-between pinning we had previously.

Percent does not have to be specifically defined anymore, since it is supported since `v0.21`.

See discussion in #406 