### PR TITLE
Upgrade test workflow to use newer versions of actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
   static-checks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -36,11 +36,11 @@ jobs:
           - python-version: "3.12"
             TOXENV: "py312"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,10 @@ jobs:
       run: tox
     - name: Upload coverage to Codecov
       if: github.repository_owner == 'instrumentkit'
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
       env:
         TOXENV: ${{ matrix.TOXENV }}
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         env_vars: TOXENV
         fail_ci_if_error: true


### PR DESCRIPTION
Switch actions to newer versions to avoid issues in the future (when older versions get dropped)

- Checout action `v4`
- Setup-python action `v5`
- Codecov action `v4`
   Double checked all variables that are set in codecov upload - they are correct. Moving up to action v4, let's see if the upload works. I'm assuming the secret is set :)