### PR TITLE
Update dev dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,12 +44,12 @@ install_requires =
 numpy = numpy
 dev =
     coverage
-    hypothesis~=6.56.0
+    hypothesis~=6.98.2
     mock
     pytest-cov
     pytest-mock
     pytest-xdist
-    pytest~=7.2.0
+    pytest~=8.0.0
     pyvisa-sim
     six
 


### PR DESCRIPTION
Ok, last one for #406:
Updating `pytest` and `hypothesis` to the latest versions. Also added a missing `__init__.py` file, which `pytest` complained about is missing due to the change in `8.0.0` of test collection.

As discussed in #406, these dependencies are still pinned to minor versions, however, to new ones. Should keep us future proof for a while longer.

Looks like all passing and good. Closes #406 