### PR TITLE
Rework Mettler Toledo init to allow for tcpip connection

### DIFF
--- a/src/instruments/mettler_toledo/mt_sics.py
+++ b/src/instruments/mettler_toledo/mt_sics.py
@@ -32,8 +32,8 @@ class MTSICS(Instrument):
         stable = False
         immediately = True
 
-    def __init__(self, filelike):
-        super().__init__(filelike)
+    def __init__(self, filelike, *args, **kwargs):
+        super().__init__(filelike, *args, **kwargs)
         self.terminator = "\r\n"
         self._weight_mode = MTSICS.WeightMode.stable
 


### PR DESCRIPTION
If you attempt to call open_tcpip with the mettler_toledo module, it will fail with an unexpected keyword argument error. This adds *args, **kwargs to __init__ and passes them to super.