### PR TITLE
Dressler Cesar 1312 RF generator

### DIFF
--- a/doc/source/apiref/dressler.rst
+++ b/doc/source/apiref/dressler.rst
@@ -1,0 +1,12 @@
+.. currentmodule:: instruments.dressler
+
+========
+Dressler
+========
+
+:class:`Cesar1312` RF Generator
+===============================
+
+.. autoclass:: Cesar1312
+    :members:
+    :undoc-members:

--- a/doc/source/apiref/index.rst
+++ b/doc/source/apiref/index.rst
@@ -14,6 +14,7 @@ Contents:
     instrument
     generic_scpi
     agilent
+    dressler
     fluke
     gentec-eo
     glassman

--- a/src/instruments/__init__.py
+++ b/src/instruments/__init__.py
@@ -12,6 +12,7 @@ from . import abstract_instruments
 from .abstract_instruments import Instrument
 
 from . import agilent
+from . import dressler
 from . import generic_scpi
 from . import fluke
 from . import gentec_eo

--- a/src/instruments/abstract_instruments/comm/serial_manager.py
+++ b/src/instruments/abstract_instruments/comm/serial_manager.py
@@ -9,6 +9,7 @@ pyserial connections can be open at the same time to the same serial port.
 
 # IMPORTS #####################################################################
 
+
 import weakref
 import serial
 
@@ -30,7 +31,7 @@ serialObjDict = weakref.WeakValueDictionary()
 # METHODS #####################################################################
 
 
-def new_serial_connection(port, baud=460800, timeout=3, write_timeout=3, parity=None):
+def new_serial_connection(port, baud=460800, timeout=3, write_timeout=3):
     """
     Return a `pyserial.Serial` connection object for the specified serial
     port address. The same object will be returned for identical port
@@ -46,26 +47,16 @@ def new_serial_connection(port, baud=460800, timeout=3, write_timeout=3, parity=
         connection. Units are seconds.
     :param write_timeout: Communication timeout for writing to the serial
         port connection. Units are seconds.
-    :param parity: Parity setting for the serial port connection. If None,
-        defaults to `serial.PARITY_NONE`, which is the default for `pyserial`.
-
     :return: A :class:`SerialCommunicator` object wrapping the connection
     :rtype: `SerialCommunicator`
     """
     if not isinstance(port, str):
         raise TypeError("Serial port must be specified as a string.")
 
-    if parity is None:
-        parity = serial.PARITY_NONE
-
     if port not in serialObjDict or serialObjDict[port] is None:
         conn = SerialCommunicator(
             serial.Serial(
-                port,
-                baudrate=baud,
-                timeout=timeout,
-                writeTimeout=write_timeout,
-                parity=parity,
+                port, baudrate=baud, timeout=timeout, writeTimeout=write_timeout
             )
         )
         serialObjDict[port] = conn

--- a/src/instruments/abstract_instruments/comm/serial_manager.py
+++ b/src/instruments/abstract_instruments/comm/serial_manager.py
@@ -9,7 +9,6 @@ pyserial connections can be open at the same time to the same serial port.
 
 # IMPORTS #####################################################################
 
-
 import weakref
 import serial
 
@@ -31,7 +30,7 @@ serialObjDict = weakref.WeakValueDictionary()
 # METHODS #####################################################################
 
 
-def new_serial_connection(port, baud=460800, timeout=3, write_timeout=3):
+def new_serial_connection(port, baud=460800, timeout=3, write_timeout=3, parity=None):
     """
     Return a `pyserial.Serial` connection object for the specified serial
     port address. The same object will be returned for identical port
@@ -47,16 +46,26 @@ def new_serial_connection(port, baud=460800, timeout=3, write_timeout=3):
         connection. Units are seconds.
     :param write_timeout: Communication timeout for writing to the serial
         port connection. Units are seconds.
+    :param parity: Parity setting for the serial port connection. If None,
+        defaults to `serial.PARITY_NONE`, which is the default for `pyserial`.
+
     :return: A :class:`SerialCommunicator` object wrapping the connection
     :rtype: `SerialCommunicator`
     """
     if not isinstance(port, str):
         raise TypeError("Serial port must be specified as a string.")
 
+    if parity is None:
+        parity = serial.PARITY_NONE
+
     if port not in serialObjDict or serialObjDict[port] is None:
         conn = SerialCommunicator(
             serial.Serial(
-                port, baudrate=baud, timeout=timeout, writeTimeout=write_timeout
+                port,
+                baudrate=baud,
+                timeout=timeout,
+                writeTimeout=write_timeout,
+                parity=parity,
             )
         )
         serialObjDict[port] = conn

--- a/src/instruments/abstract_instruments/instrument.py
+++ b/src/instruments/abstract_instruments/instrument.py
@@ -5,6 +5,7 @@ Provides the base Instrument class for all instruments.
 
 # IMPORTS #####################################################################
 
+
 import os
 import collections
 import socket
@@ -471,7 +472,6 @@ class Instrument:
         serial_number=None,
         timeout=3,
         write_timeout=3,
-        parity=None,
     ):
         """
         Opens an instrument, connecting via a physical or emulated serial port.
@@ -498,8 +498,6 @@ class Instrument:
             instrument before timing out.
         :param float write_timeout: Number of seconds to wait when writing to the
             instrument before timing out.
-        :param int parity: Choose the parity according to pyserial's
-            documentation or None for default.
 
         :rtype: `Instrument`
         :return: Object representing the connected instrument.
@@ -557,7 +555,7 @@ class Instrument:
             )
 
         ser = serial_manager.new_serial_connection(
-            port, baud=baud, timeout=timeout, write_timeout=write_timeout, parity=parity
+            port, baud=baud, timeout=timeout, write_timeout=write_timeout
         )
         return cls(ser)
 

--- a/src/instruments/abstract_instruments/instrument.py
+++ b/src/instruments/abstract_instruments/instrument.py
@@ -5,7 +5,6 @@ Provides the base Instrument class for all instruments.
 
 # IMPORTS #####################################################################
 
-
 import os
 import collections
 import socket
@@ -472,6 +471,7 @@ class Instrument:
         serial_number=None,
         timeout=3,
         write_timeout=3,
+        parity=None,
     ):
         """
         Opens an instrument, connecting via a physical or emulated serial port.
@@ -498,6 +498,8 @@ class Instrument:
             instrument before timing out.
         :param float write_timeout: Number of seconds to wait when writing to the
             instrument before timing out.
+        :param int parity: Choose the parity according to pyserial's
+            documentation or None for default.
 
         :rtype: `Instrument`
         :return: Object representing the connected instrument.
@@ -555,7 +557,7 @@ class Instrument:
             )
 
         ser = serial_manager.new_serial_connection(
-            port, baud=baud, timeout=timeout, write_timeout=write_timeout
+            port, baud=baud, timeout=timeout, write_timeout=write_timeout, parity=parity
         )
         return cls(ser)
 

--- a/src/instruments/dressler/__init__.py
+++ b/src/instruments/dressler/__init__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+"""
+Module containing Dressler instruments
+"""
+
+from instruments.dressler.cesar_1312 import Cesar1312

--- a/src/instruments/dressler/cesar_1312.py
+++ b/src/instruments/dressler/cesar_1312.py
@@ -1,0 +1,395 @@
+"""Support for Dressler Cesar 1312 RF generator."""
+
+# IMPORTS #####################################################################
+
+from enum import IntEnum
+from typing import Union
+
+from instruments.abstract_instruments import Instrument
+from instruments.units import ureg as u
+from instruments.util_fns import assume_units
+
+# CLASSES #####################################################################
+
+
+class Cesar1312(Instrument):
+    """Communicate with the Dressler Cesar 1312 RF generator.
+
+    Various connection options are available for different models.
+    This driver has been tested using the RS-232 option. Note that
+    you need to set the parity to `serial.PARITY_ODD` for this
+    instrument to work.
+
+    TODO: Check if instrument needs to be put into remote mode or not...
+    TODO: Example usage
+
+    Example:
+        >>> import serial
+        >>> import instruments as ik
+        >>> port = '/dev/ttyUSB0'
+        >>> baud = 9600
+        >>> parity = serial.PARITY_ODD
+        >>> inst = ik.dressler.Cesar1312.open_serial(port, baud, parity=parity)
+    """
+
+    class ControlMode(IntEnum):
+        """Control modes of the Cesar 1312 RF generator."""
+
+        Host = 2
+        UserPort = 4
+        FrontPanel = 6
+
+    class RegulationMode(IntEnum):
+        """Regulation modes of the Cesar 1312 RF generator."""
+
+        ForwardPower = 6
+        LoadPower = 7
+        ExternalPower = 8
+
+    def __init__(self, filelike):
+        super().__init__(filelike)
+
+        self._retries = 3
+
+        self._csr_codes = {
+            0: "OK",
+            1: "Command rejected because unit is in wrong control mode.",
+            2: "Command rejected because RF output is on.",
+            4: "Command rejected because data sent is out of range.",
+            5: "Command rejected because User Port RF signal is off.",
+            7: "Command rejected because active fault(s) exist in generator.",
+            9: "Command rejected because the data byte count is incorrect.",
+            19: "Command rejected because the recipe mode is active",
+            50: "Command rejected because the frequency is out of range.",
+            51: "Command rejected because the duty cycle is out of range.",
+            99: "Command not implemented.",
+        }
+        self._address = 0x01
+        self._ack = bytes([0x06])
+        self._nak = bytes([0x15])
+
+    # CLASS PROPERTIES #
+
+    @property
+    def address(self) -> int:
+        """Set/get the address of the device.
+
+        Note that an address of 0 is the broadcast address.
+        Most likely, you can leave this at the default of 1.
+
+        :return: The set address.
+        :rtype: int
+        """
+        return self._address
+
+    @address.setter
+    def address(self, value: int) -> None:
+        if value < 0 or value > 31:
+            raise ValueError("Address must be in the range 0-31.")
+        self._address = value
+
+    @property
+    def retries(self) -> int:
+        """Set/get the number of retries if a command fails.
+
+        :return: The number of retries as an integer.
+        :rtype: int
+        """
+        return self._retries
+
+    @retries.setter
+    def retries(self, value: int) -> tuple[int, int, bytes]:
+        if value < 0:
+            raise ValueError("Retries must be greater than or equal to 0.")
+        self._retries = value
+
+    # INSTRUMENT PROPERTIES #
+
+    @property
+    def control_mode(self) -> ControlMode:
+        """Set/get the active control of the RF generator.
+
+        Possible values are given in the `ControlMode` enum. For computer
+        control, you likely want to set this to `ControlMode.Host`.
+
+        ..note:: If you set the control mode at any time back to
+            `ControlMode.FrontPanel`, the RF will turn off.
+
+        :return: The current control mode.
+        :rtype: ControlMode
+
+        Example:
+            >>> inst.control_mode = ik.dressler.Cesar1312.ControlMode.Host
+            >>> inst.control_mode
+            <ControlMode.Host: 2>
+        """
+        cmd = 155
+        ret_val = self.query(self._make_pkg(cmd, None))
+        # FIXME: make this prettier once tests are in place
+        ret_val = int(ret_val.hex(), 16)
+        return self.ControlMode(ret_val)
+
+    @control_mode.setter
+    def control_mode(self, value: ControlMode) -> None:
+        # FIXME:
+        data = value.value
+        cmd = 14
+        self.sendcmd(self._make_pkg(cmd, self._make_data(1, data)))
+
+    @property
+    def regulation_mode(self) -> RegulationMode:
+        """Set/get the regulation mode.
+
+        Possible values are given in the `RegulationMode` enum.
+
+        :return: The current regulation mode.
+        :rtype: RegulationMode
+
+        Example:
+            >>> inst.regulation_mode = ik.dressler.Cesar1312.RegulationMode.ForwardPower
+            >>> inst.regulation_mode
+            <RegulationMode.ForwardPower: 6>
+        """
+        data = None
+        cmd = 154
+        data = self.query(self._make_pkg(cmd, data))
+        data = int(data.hex(), 16)
+        return self.RegulationMode(data)
+
+    @regulation_mode.setter
+    def regulation_mode(self, value: RegulationMode) -> None:
+        data = value.value
+        cmd = 3
+        self.sendcmd(self._make_pkg(cmd, self._make_data(1, data)))
+
+    @property
+    def rf(self) -> bool:
+        """Set/get the RF output state of the device.
+
+        RF on will be `True` while RF off will be `False`.
+
+        :return: The current RF state.
+        :rtype: bool
+
+        Example:
+            >>> inst.rf = True
+            >>> inst.rf
+            True
+        """
+        # FIXME:
+        raise NotImplementedError("Getting the RF state is not yet implemented.")
+
+    @rf.setter
+    def rf(self, value: bool) -> None:
+        cmd = 2 if value else 1
+        pkg = self._make_pkg(cmd, None)
+        self.sendcmd(pkg)
+
+    @property
+    def setpoint(self) -> int:
+        """Set/get the setpoint of the device in W."""
+        # FIXME: Rename, clean up, unitful
+        cmd = 164
+        pkg = self._make_pkg(cmd, None)
+        ret_data = self.query(pkg)[:2]
+        # TODO: Check if this is correct.
+        return ret_data.to_bytes(2, "little")
+        # return struct.unpack("<H", ret_data)[0]
+
+    @setpoint.setter
+    def setpoint(self, value: int) -> None:
+        # FIXME: Rename, clean up
+        data = self._make_data(2, value)
+        cmd = 8
+        self.sendcmd(self._make_pkg(cmd, data))
+
+    @property
+    def status(self):  # TODO: DEFINE RETURN TYPE
+        """Get the status via cmd 162"""
+        # FIXME: see writeup from initial test...
+        cmd = 162
+        pkg = self._make_pkg(cmd, None)
+        ret_data = self.query(pkg)
+        return ret_data.hex(":").split(":")
+
+    # METHODS #
+
+    def query(self, package: bytes, len_data=1) -> bytes:
+        """Send a package to the instrument, assert it's all good, and return answer.
+
+        This sends the package and checks the response. If the response is NAK,
+        it retries until an ACK is received or the number of retries is reached.
+
+        Once an ACK is received, it listens for the response of the instrument
+        parsed the header, command, and optinally the data length (if > 6),
+        then listens to the data and checksum and ensures that the overallc hecksum
+        is zero. If not, it will send a NAK and retry reading until the checksum is
+        zero. Then it will send an ACK to finish the communication.
+
+        :param bytes package: The package to send.
+
+        :return: The data received from the device.
+        :rtype: bytes
+        """
+        tries = 0
+        got_ack = False
+        while tries < self.retries + 1:
+            self._file.write_raw(package)
+            response = self.read_raw(1)
+            if response == self._ack:
+                got_ack = True
+                break
+            else:
+                tries += 1
+
+        if not got_ack:
+            raise OSError("Failed to get ACK from device after sending the command.")
+
+        tries = 0
+        got_pkg = False
+        while tries < self.retries:
+            header = self.read_raw(1)
+            cmd = self.read_raw(1)
+
+            adr, dlength = self._unpack_header(header)
+
+            optional_data_length = None
+            if dlength == 0b111:
+                optional_data_length = self.read_raw(1)
+                dlength = int(optional_data_length.hex(), 16)
+
+            data = self.read_raw(dlength) if dlength > 0 else None
+
+            checksum = self.read_raw(1)
+
+            pkg = header + cmd
+            if optional_data_length:
+                pkg += optional_data_length
+            pkg += data
+            pkg += checksum
+
+            if self._calculate_checksum(pkg) == bytes([0x0]):
+                self._file.write_raw(self._ack)
+                got_pkg = True
+                break
+            else:
+                tries += 1
+                self._file.write_raw(self._nak)
+
+        if not got_pkg:
+            raise OSError("Failed to get a valid package from the device.")
+
+        return data
+
+    def sendcmd(self, pkg: bytes) -> None:
+        """Send a package to the instrument and assert it's all good.
+
+        Uses the query routine and interprets the data, which should be one byte,
+        as a CSR. If the CSR is not OK (0), will print a warning with the message.
+
+        :param bytes pkg: The package to send.
+        """
+        data = self.query(pkg)
+        if data:
+            csr = int(data.hex(), 16)
+            if csr != 0:
+                # FIXME: This should raise an exception instead
+                print(f"Warning: {self._csr_codes[csr]}")
+        else:
+            raise ValueError("No data received from the device.")
+
+    def _make_data(
+        self, length: Union[int, list[int]], data: Union[int, list[int]]
+    ) -> bytes:
+        """Create the data bytes for the package.
+
+        If only one number is given, provide the length and the actual value as integers (or list).
+        If more than one number is given, provide both as lists.
+
+        :param Union[int, list[int]] length: The length of the data.
+        :param Union[int, list[int]] data: The data to send.
+
+        :return: Data in appropriate order.
+        :rtype: bytes
+        """
+        if isinstance(length, int):
+            length = [length]
+        if isinstance(data, int):
+            data = [data]
+
+        data_bytes = b""
+        for ll, dd in zip(length, data):
+            data_bytes += dd.to_bytes(ll, byteorder="little", signed=False)
+
+        return data_bytes
+
+    def _make_pkg(self, cmd_number: int, data: Union[None, bytes] = None) -> bytes:
+        """Make a package and return it packed as bytes.
+
+        :param int cmd_number: The command number.
+        :param bytes data: The data to send, already in proper order as bytes, or None.
+            Defaults to None, which makes it a query command.
+        """
+        data_length = len(data) if data else 0
+
+        header = self._pack_header(self.address, data_length)
+
+        if data_length > 255:
+            raise ValueError("Data length too long, must be <= 255.")
+
+        if cmd_number > 255:
+            raise ValueError("Command number too long, must be <= 255.")
+
+        if data_length > 6:
+            pkg = [header, cmd_number, data_length]
+        else:
+            pkg = [header, cmd_number]
+
+        pkg = bytes(pkg)
+        if data is not None:
+            pkg += data
+
+        pkg = pkg + self._calculate_checksum(pkg)
+        return pkg
+
+    @staticmethod
+    def _calculate_checksum(data: bytes) -> bytes:
+        """Calculate the checksum of the data.
+
+        :param bytes data: The data to calculate the checksum for.
+
+        :return: Checksum.
+        :rtype: bytes
+        """
+        checksum = data[0]
+        for it, bt in enumerate(data):
+            if it > 0:
+                checksum ^= bt
+        return bytes([checksum])
+
+    @staticmethod
+    def _pack_header(address: int, data_length: int):
+        """Make the header of the package.
+
+        :param int address: The address of the device.
+        :param int data_length: The length of the data. If > 6, will be set to 7.
+
+        :return: The header as an integer.
+        """
+        # FIXME: should return header as bytes, should read address from class
+        if data_length > 6:
+            data_length = 7  # need an extra byte for data length
+        return (address << 3) + data_length
+
+    @staticmethod
+    def _unpack_header(hdr: bytes) -> tuple[int]:
+        """Parse the header and return address and data length.
+
+        :param bytes hdr: The header byte.
+
+        :return: The address and data length as integers.
+        :rtype: tuple[int]
+        """
+        addr = hdr[0] >> 3
+        data_length = hdr[0] & 0b00000111
+        return addr, data_length

--- a/src/instruments/dressler/cesar_1312.py
+++ b/src/instruments/dressler/cesar_1312.py
@@ -137,6 +137,21 @@ class Cesar1312(Instrument):
         self.sendcmd(self._make_pkg(14, self._make_data(1, value.value)))
 
     @property
+    def name(self) -> str:
+        """Get the supply type and size of the RF generator.
+
+        :return: The supply type and size.
+        :rtype: str
+
+        Example:
+            >>> inst.name
+            'CESAR_1312'
+        """
+        name_type = self.query(self._make_pkg(128)).decode("utf-8")
+        name_size = self.query(self._make_pkg(129)).decode("utf-8")
+        return f"{name_type}{name_size}"
+
+    @property
     def output_power(self) -> u.Quantity:
         """Set/get the output power of the device in W.
 
@@ -298,7 +313,7 @@ class Cesar1312(Instrument):
             csr = int(data.hex(), 16)
             if csr != 0:
                 raise OSError(
-                    f"{self._crs_codes.get(csr, 'Unknown error')} (CSR={csr})"
+                    f"{self._csr_codes.get(csr, 'Unknown error')} (CSR={csr})"
                 )
         else:
             raise ValueError("No data received from the device.")

--- a/src/instruments/dressler/cesar_1312.py
+++ b/src/instruments/dressler/cesar_1312.py
@@ -18,12 +18,12 @@ class Cesar1312(Instrument):
     """Communicate with the Dressler Cesar 1312 RF generator.
 
     Various connection options are available for different models.
-    This driver has been tested using the RS-232 option. Note that
-    you need to set the parity to `serial.PARITY_ODD` for this
-    instrument to work.
+    This driver has been tested using the RS-232 option.
+    Upon initialization, the instrument is automatically put into
+    odd parity communication mode (as required by the device).
 
-    TODO: Check if instrument needs to be put into remote mode or not...
-    TODO: Example usage
+    Note that you must set the control mode to `ControlMode.Host`
+    in order to send any commands from the computer to the device.
 
     Example:
         >>> import serial
@@ -31,6 +31,7 @@ class Cesar1312(Instrument):
         >>> port = '/dev/ttyUSB0'
         >>> baud = 9600
         >>> inst = ik.dressler.Cesar1312.open_serial(port, baud)
+        >>> inst.control_mode = inst.ControlMode.Host
         >>> inst.rf  # query RF state
         False
         >>> inst.rf = True  # turn on RF

--- a/src/instruments/dressler/cesar_1312.py
+++ b/src/instruments/dressler/cesar_1312.py
@@ -29,7 +29,7 @@ class Cesar1312(Instrument):
         >>> import serial
         >>> import instruments as ik
         >>> port = '/dev/ttyUSB0'
-        >>> baud = 9600
+        >>> baud = 115200
         >>> inst = ik.dressler.Cesar1312.open_serial(port, baud)
         >>> inst.control_mode = inst.ControlMode.Host
         >>> inst.rf  # query RF state

--- a/src/instruments/dressler/cesar_1312.py
+++ b/src/instruments/dressler/cesar_1312.py
@@ -3,7 +3,7 @@
 # IMPORTS #####################################################################
 
 from enum import IntEnum
-from typing import Union
+from typing import List, Tuple, Union
 
 import serial
 
@@ -105,7 +105,7 @@ class Cesar1312(Instrument):
         return self._retries
 
     @retries.setter
-    def retries(self, value: int) -> tuple[int, int, bytes]:
+    def retries(self, value: int) -> Tuple[int, int, bytes]:
         if value < 0:
             raise ValueError("Retries must be greater than or equal to 0.")
         self._retries = value
@@ -320,7 +320,7 @@ class Cesar1312(Instrument):
             raise ValueError("No data received from the device.")
 
     def _make_data(
-        self, length: Union[int, list[int]], data: Union[int, list[int]]
+        self, length: Union[int, List[int]], data: Union[int, List[int]]
     ) -> bytes:
         """Create the data bytes for the package.
 
@@ -400,7 +400,7 @@ class Cesar1312(Instrument):
         return (self._address << 3) + data_length
 
     @staticmethod
-    def _unpack_header(hdr: bytes) -> tuple[int]:
+    def _unpack_header(hdr: bytes) -> Tuple[int]:
         """Parse the header and return address and data length.
 
         :param bytes hdr: The header byte.

--- a/tests/test_dressler/test_cesar_1312.py
+++ b/tests/test_dressler/test_cesar_1312.py
@@ -455,7 +455,7 @@ def test_pack_header(addr, data_length):
 @given(hdr_int=st.integers(min_value=0, max_value=255))
 def test_unpack_header(hdr_int):
     """Unpack a header to return address and data length."""
-    hdr = hdr_int.to_bytes(1)
+    hdr = hdr_int.to_bytes(1, "little")
     with expected_protocol(
         ik.dressler.Cesar1312,
         [],

--- a/tests/test_dressler/test_cesar_1312.py
+++ b/tests/test_dressler/test_cesar_1312.py
@@ -24,6 +24,7 @@ def test_address():
         ik.dressler.Cesar1312,
         [],
         [],
+        sep="",
     ) as rf:
         assert rf.address == 0x01
         rf.address = 5
@@ -40,6 +41,7 @@ def test_retries():
         ik.dressler.Cesar1312,
         [],
         [],
+        sep="",
     ) as rf:
         assert rf.retries == 3
         rf.retries = 5
@@ -195,6 +197,7 @@ def test_make_pkg():
         ik.dressler.Cesar1312,
         [],
         [],
+        sep="",
     ) as rf:
         # simple query package with command 1
         pkg_exp = bytes([0b00001000, 0x01])
@@ -246,6 +249,7 @@ def test_make_pkg_error():
         ik.dressler.Cesar1312,
         [],
         [],
+        sep="",
     ) as rf:
         with pytest.raises(ValueError):
             rf._make_pkg(256, None)
@@ -262,6 +266,7 @@ def test_checksum(values):
         ik.dressler.Cesar1312,
         [],
         [],
+        sep="",
     ) as rf:
         checksum = rf._calculate_checksum(bts)[0]
         for val in bts:
@@ -279,6 +284,7 @@ def test_pack_header(addr, data_length):
         ik.dressler.Cesar1312,
         [],
         [],
+        sep="",
     ) as rf:
         rf.address = addr
         header = rf._pack_header(data_length)
@@ -295,6 +301,7 @@ def test_unpack_header(hdr_int):
         ik.dressler.Cesar1312,
         [],
         [],
+        sep="",
     ) as rf:
         addr, dl = rf._unpack_header(hdr)
         assert addr == hdr_int >> 3

--- a/tests/test_dressler/test_cesar_1312.py
+++ b/tests/test_dressler/test_cesar_1312.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+"""Tests for the Dressler Cesar 1312 RF generator."""
+
+from hypothesis import HealthCheck, given, settings, strategies as st
+import pytest
+
+import instruments as ik
+from instruments.units import ureg as u
+from tests import expected_protocol
+
+# CONSTANTS #
+
+
+ACK = bytes([0x06])
+NAK = bytes([0x15])
+
+
+# TEST CLASS PROPERTIES #
+
+
+def test_address():
+    """Set/get the address of the instrument."""
+    with expected_protocol(
+        ik.dressler.Cesar1312,
+        [],
+        [],
+    ) as rf:
+        assert rf.address == 0x01
+        rf.address = 5
+        assert rf.address == 5
+
+        for addr in [-1, 32]:
+            with pytest.raises(ValueError):
+                rf.address = addr
+
+
+def test_retries():
+    """Set/get the number of retries."""
+    with expected_protocol(
+        ik.dressler.Cesar1312,
+        [],
+        [],
+    ) as rf:
+        assert rf.retries == 3
+        rf.retries = 5
+        assert rf.retries == 5
+
+        with pytest.raises(ValueError):
+            rf.retries = -1
+
+
+# TEST INSTRUMENT PROPERTIES #
+
+
+def test_rf():
+    """Set/get the RF output state."""
+    RF_ON = bytes([0x08, 0x02, 0x0A])
+    RF_ON_ANSW = bytes([0x09, 0x02, 0x00, 0x0B])
+    RF_OFF = bytes([0x08, 0x01, 0x09])
+    RF_OFF_ANSW = bytes([0x09, 0x01, 0x00, 0x08])
+    with expected_protocol(
+        ik.dressler.Cesar1312,
+        [RF_ON, ACK, RF_OFF, ACK],
+        [
+            ACK,
+            RF_ON_ANSW,
+            ACK,
+            RF_OFF_ANSW,
+        ],
+        sep="",
+    ) as rf:
+        # TODO: assert rf.rf == False
+        rf.rf = True
+        rf.rf = False
+        # TODO: assert rf.rf == True
+
+
+# TEST PRIVATE METHODS #
+
+
+def test_make_pkg():
+    """Create a package that can be sent to the instrument."""
+    with expected_protocol(
+        ik.dressler.Cesar1312,
+        [],
+        [],
+    ) as rf:
+        # simple query package with command 1
+        pkg_exp = bytes([0b00001000, 0x01])
+        pkg_exp += rf._calculate_checksum(pkg_exp)
+
+        pkg = rf._make_pkg(1, None)
+        assert pkg == pkg_exp
+
+        pkg = rf._make_pkg(1)  # should be same as above
+        assert pkg == pkg_exp
+
+        # change address to 3 and send 4 bytes of 1024 to command 2
+        pkg_exp = bytes([0b00011100, 0x02, 0x00, 0x04, 0x00, 0x00])
+        pkg_exp += rf._calculate_checksum(pkg_exp)
+
+        rf.address = 3
+        pkg = rf._make_pkg(2, (1024).to_bytes(4, "little"))
+
+        assert pkg == pkg_exp
+
+        # some long command with lots of data, using the make data pkg
+        rf.address = 1
+        pkg_exp = bytes(
+            [
+                0b00001111,
+                0x01,
+                0x09,
+                0x01,
+                0x02,
+                0x03,
+                0x04,
+                0x05,
+                0x00,
+                0x04,
+                0x00,
+                0x00,
+            ]
+        )
+        data = rf._make_data([1, 1, 1, 1, 1, 4], [1, 2, 3, 4, 5, 1024])
+        pkg_exp += rf._calculate_checksum(pkg_exp)
+
+        pkg = rf._make_pkg(1, data)
+        assert pkg == pkg_exp
+
+
+def test_make_pkg_error():
+    """Raise error if cmd is too large or data is too long."""
+    with expected_protocol(
+        ik.dressler.Cesar1312,
+        [],
+        [],
+    ) as rf:
+        with pytest.raises(ValueError):
+            rf._make_pkg(256, None)
+
+        with pytest.raises(ValueError):
+            rf._make_pkg(1, (1).to_bytes(256, "little"))
+
+
+@given(values=st.lists(st.integers(min_value=0, max_value=255), min_size=1))
+def test_checksum(values):
+    """Assure that exclusive or of all bytes plus checksum is 0."""
+    bts = bytes(values)
+    with expected_protocol(
+        ik.dressler.Cesar1312,
+        [],
+        [],
+    ) as rf:
+        checksum = rf._calculate_checksum(bts)[0]
+        for val in bts:
+            checksum ^= val
+        assert checksum == 0
+
+
+@given(
+    addr=st.integers(min_value=0, max_value=31),
+    data_length=st.integers(min_value=0, max_value=255),
+)
+def test_pack_header(addr, data_length):
+    """Pack the header of the package."""
+    with expected_protocol(
+        ik.dressler.Cesar1312,
+        [],
+        [],
+    ) as rf:
+        rf.address = addr
+        header = rf._pack_header(addr, data_length)
+        dl = 7 if data_length > 6 else data_length
+        header_exp = (addr << 3) + dl
+        assert header == header_exp
+
+
+@given(hdr_int=st.integers(min_value=0, max_value=255))
+def test_unpack_header(hdr_int):
+    """Unpack a header to return address and data length."""
+    hdr = hdr_int.to_bytes(1)
+    with expected_protocol(
+        ik.dressler.Cesar1312,
+        [],
+        [],
+    ) as rf:
+        addr, dl = rf._unpack_header(hdr)
+        assert addr == hdr_int >> 3
+        assert dl == hdr_int & 0b00000111

--- a/tests/test_dressler/test_cesar_1312.py
+++ b/tests/test_dressler/test_cesar_1312.py
@@ -295,7 +295,7 @@ def test_unknown_command():
     ) as rf:
         with pytest.raises(OSError) as err:
             rf.sendcmd(rf._make_pkg(0))
-            assert "Command not implemented" in err.value.args[0]
+        assert "Command not implemented" in err.value.args[0]
 
 
 def test_device_returns_no_data():
@@ -316,7 +316,7 @@ def test_device_returns_no_data():
     ) as rf:
         with pytest.raises(ValueError) as err:
             rf.sendcmd(rf._make_pkg(0))
-            assert "No data received from the device" in err.value.args[0]
+        assert "No data received from the device" in err.value.args[0]
 
 
 def test_answer_longer_six_bytes():


### PR DESCRIPTION
Here's support for the Dressler Cesar 1312 RF generator. An older instrument, but works great via RS232. The most important commands are implemented and especially the package sending/receiving are working very well. Functionality that is covered:

- Select control mode 
- Select regulation mode
- Set/get the output power
- Read back reflected power
- Turn on/off RF and read status

Test coverage included, added to docs.

Curious to hear your opinion @scasagrande. There is no dedicated RF generator, so inheriting from Instruments. Might be something to think about...