### PR TITLE
Comet cito plus 1310 RF generator

### DIFF
--- a/doc/source/apiref/comet.rst
+++ b/doc/source/apiref/comet.rst
@@ -1,0 +1,12 @@
+.. currentmodule:: instruments.comet
+
+=====
+Comet
+=====
+
+:class:`CitoPlus1310` RF Generator
+=========================================
+
+.. autoclass:: CitoPlus1310
+    :members:
+    :undoc-members:

--- a/doc/source/apiref/index.rst
+++ b/doc/source/apiref/index.rst
@@ -14,6 +14,7 @@ Contents:
     instrument
     generic_scpi
     agilent
+    comet
     fluke
     gentec-eo
     glassman

--- a/src/instruments/__init__.py
+++ b/src/instruments/__init__.py
@@ -12,6 +12,7 @@ from . import abstract_instruments
 from .abstract_instruments import Instrument
 
 from . import agilent
+from . import comet
 from . import generic_scpi
 from . import fluke
 from . import gentec_eo

--- a/src/instruments/comet/__init__.py
+++ b/src/instruments/comet/__init__.py
@@ -1,0 +1,5 @@
+"""
+Module containing Comet instruments.
+"""
+
+from .cito_plus_1310 import CitoPlus1310

--- a/src/instruments/comet/cito_plus_1310.py
+++ b/src/instruments/comet/cito_plus_1310.py
@@ -1,0 +1,516 @@
+#!/usr/bin/env python
+"""Support for Comet Cito Plus RF generator."""
+
+# IMPORTS #####################################################################
+
+from enum import IntEnum
+from typing import Union
+
+import serial
+
+from instruments.abstract_instruments import Instrument
+from instruments.units import ureg as u
+from instruments.util_fns import assume_units
+
+# CLASSES #####################################################################
+
+
+class CitoPlus1310(Instrument):
+    """Communicate with the Comet Cito Plus 1310 RF generator.
+
+    Various connection options are available for different models.
+    Note that this driver is only tested with the RS-232 interface
+    and that, according to the manual, communication over TCP/IP is
+    different.
+
+    Example:
+        >>> import instruments as ik
+        >>> port = '/dev/ttyUSB0'
+        >>> baud = 15200
+        >>> inst = ik.comet.CitoPlus1310.open_serial(port, baud)
+        >>> inst.rf  # query RF state
+        False
+        >>> inst.rf = True  # turn on RF
+    """
+
+    class RegulationMode(IntEnum):
+        """Regulation modes that are available on the Cito Plus 1310."""
+
+        ForwardPower = 0
+        LoadPower = 1
+        ProcessControl = 2
+
+    def __init__(self, filelike):
+        super().__init__(filelike)
+        self._file.parity = serial.PARITY_EVEN
+
+        self._address = 0x0A
+
+        self._exception_codes = {
+            0x01: "Unknown parameter or illegal function code",
+            0x04: "Value invalid",
+            0x05: "Parameter not writable",
+            0x06: "Parameter not readable",
+            0x07: "Stop",
+            0x08: "Not allowed",
+            0x09: "Wrong data type",
+            0x0A: "Internal error",
+            0x0B: "Value too high",
+            0x0C: "Value too low",
+        }
+
+        self._byte_order = "big"  # byte order for command and data
+        self._byte_order_crc = "little"  # byte order for CRC-16 checksum
+
+    @property
+    def name(self) -> str:
+        """Get the name of the instrument."""
+        data = self.query(self._make_pkg(10))
+        return data.decode("utf-8")
+
+    @property
+    def forward_power(self) -> u.Quantity:
+        """Get the actual forward power of the generator in W.
+
+        :return: Forward power.
+        :rtype: Quantity
+        """
+        data = self.query(self._make_pkg(8022))
+        data = int.from_bytes(data, byteorder=self._byte_order) * u.W
+        return data
+
+    @property
+    def output_power(self) -> u.Quantity:
+        """Get/set the set output power of the generator in W.
+
+        :return: Output power.
+        :rtype: Quantity
+        """
+        data = self.query(self._make_pkg(1206))
+        data = int.from_bytes(data, byteorder=self._byte_order) * u.mW
+        return data.to(u.W)
+
+    @output_power.setter
+    def output_power(self, value: u.Quantity) -> None:
+        value = assume_units(value, u.W).to(u.mW)
+        value = int(value.magnitude)
+        self.sendcmd(self._make_pkg(1206, value))
+
+    @property
+    def reflected_power(self) -> u.Quantity:
+        """Get the actual reflected power of the generator in W.
+
+        :return: Reflected power.
+        :rtype: Quantity
+        """
+        data = self.query(self._make_pkg(8021))
+        data = int.from_bytes(data, byteorder=self._byte_order) * u.W
+        return data
+
+    @property
+    def regulation_mode(self) -> RegulationMode:
+        """Get/set the regulation mode of the generator.
+
+        :return: Regulation mode.
+        :rtype: RegulationMode
+        """
+        data = self.query(self._make_pkg(1201))
+        return self.RegulationMode(int.from_bytes(data, byteorder=self._byte_order))
+
+    @regulation_mode.setter
+    def regulation_mode(self, value) -> None:
+        self.sendcmd(self._make_pkg(1201, value.value))
+
+    @property
+    def rf(self) -> bool:
+        """Get/set the RF state.
+
+        :return: The RF state.
+        :rtype: bool
+        """
+        data = self.query(self._make_pkg(8000))
+        return int.from_bytes(data, byteorder=self._byte_order) != 1
+
+    @rf.setter
+    def rf(self, value: bool) -> None:
+        data = 1 if value else 0
+        self.sendcmd(self._make_pkg(1001, data))
+
+    def sendcmd(self, pkg: bytes) -> None:
+        """Write a command to the instrument.
+
+        Uses the query command to check return, i.e., that everything is fine,
+        but does not return data.
+
+        :param bytes pkg: The package to send to the instrument.
+        """
+        self.query(pkg, write_cmd=True)
+
+    def query(self, pkg: bytes, write_cmd=False) -> Union[None, bytes]:
+        """Query instrument.
+
+        This will check if the command is accepted by the instrument and if not,
+        raise an OSError with the appropriate return code that came back.
+
+        :param bytes pkg: The package to send to the instrument.
+        :param boolwrite_cmd: If True, this is a write command and will only check
+                if received package the same as sent one.
+        """
+        self._file.write_raw(pkg)
+
+        hdr = self._file.read_raw(2)
+        fn_code = hdr[1]
+
+        if fn_code != 0x41 and fn_code != 0x42:
+            exc_code = self._file.read_raw(1)[0]
+            self._check_exception(fn_code, exc_code)
+
+        if write_cmd:
+            # read the rest, make sure the packages agree and if not raise OSError.
+            len_to_read = len(pkg) - 2
+            rest = self._file.read_raw(len_to_read)
+            pkg_return = hdr + rest
+            if pkg_return != pkg:
+                raise OSError("Received package does not match sent package.")
+            return
+
+        # so it is a query and we expect data
+        data_length = self._file.read_raw(1)
+        data = self._file.read_raw(int.from_bytes(data_length))
+        crc = self._file.read_raw(2)
+
+        crc_exp = _crc16(hdr + data_length + data).to_bytes(
+            2, byteorder=self._byte_order_crc
+        )
+
+        if crc != crc_exp:
+            raise OSError("CRC-16 checksum of returned package does not match.")
+
+        return data
+
+    def _check_exception(self, fn_code: int, exc_code: int) -> None:
+        """Checks if the function code is an exception and raises an OSError if so.
+
+        :param int fn_code: The function code.
+        :param int exc_code: The exception code.
+
+        :raises OSError: If the function code is an exception.
+        """
+        if fn_code != 0x41 or fn_code != 0x42:
+            raise OSError(
+                f"Exception code: {hex(exc_code)}: {self._exception_codes.get(exc_code, 'Unknown')}"
+            )
+
+    def _make_hdr(self, fn_code: int) -> bytes:
+        """Make the header according to our init settings.
+
+        :param int fn_code: The function code to use.
+
+        :return: The header bytes.
+        :rtype: bytes
+        """
+        hdr = bytes([self._address, fn_code])
+        return hdr
+
+    def _make_pkg(self, cmd_code, data=None, data_length=4):
+        """Create a package to send to the instrument.
+
+        :param int cmd_code: The command code.
+        :param data: The data to send. If None, this is a read command. Defaults to None.
+        :param int data_length: The length of the data in bytes. Only used when writing.
+
+        :return: Properly packed data to send to the instrument.
+        :rtype: bytes
+        """
+        if data is None:
+            fn_code = 0x41
+        else:
+            fn_code = 0x42
+
+        hdr = self._make_hdr(fn_code)
+
+        cmd = cmd_code.to_bytes(length=2, byteorder=self._byte_order)
+
+        if data is not None:
+            dat = data.to_bytes(length=data_length, byteorder=self._byte_order)
+        else:
+            dat = (0x01).to_bytes(length=2, byteorder=self._byte_order)
+
+        pkg = hdr + cmd + dat
+        crc = _crc16(pkg)
+        crc_bytes = crc.to_bytes(2, byteorder=self._byte_order_crc)
+
+        return pkg + crc_bytes
+
+
+def _crc16(data: bytes):
+    """Create the CRC-16 checksum for the given data.
+
+    :param bytes data: The data for which to create the checksum.
+
+    :return: The CRC-16 checksum.
+    :rtype: int
+    """
+    crc16tab = [
+        0x0000,
+        0xC0C1,
+        0xC181,
+        0x0140,
+        0xC301,
+        0x03C0,
+        0x0280,
+        0xC241,
+        0xC601,
+        0x06C0,
+        0x0780,
+        0xC741,
+        0x0500,
+        0xC5C1,
+        0xC481,
+        0x0440,
+        0xCC01,
+        0x0CC0,
+        0x0D80,
+        0xCD41,
+        0x0F00,
+        0xCFC1,
+        0xCE81,
+        0x0E40,
+        0x0A00,
+        0xCAC1,
+        0xCB81,
+        0x0B40,
+        0xC901,
+        0x09C0,
+        0x0880,
+        0xC841,
+        0xD801,
+        0x18C0,
+        0x1980,
+        0xD941,
+        0x1B00,
+        0xDBC1,
+        0xDA81,
+        0x1A40,
+        0x1E00,
+        0xDEC1,
+        0xDF81,
+        0x1F40,
+        0xDD01,
+        0x1DC0,
+        0x1C80,
+        0xDC41,
+        0x1400,
+        0xD4C1,
+        0xD581,
+        0x1540,
+        0xD701,
+        0x17C0,
+        0x1680,
+        0xD641,
+        0xD201,
+        0x12C0,
+        0x1380,
+        0xD341,
+        0x1100,
+        0xD1C1,
+        0xD081,
+        0x1040,
+        0xF001,
+        0x30C0,
+        0x3180,
+        0xF141,
+        0x3300,
+        0xF3C1,
+        0xF281,
+        0x3240,
+        0x3600,
+        0xF6C1,
+        0xF781,
+        0x3740,
+        0xF501,
+        0x35C0,
+        0x3480,
+        0xF441,
+        0x3C00,
+        0xFCC1,
+        0xFD81,
+        0x3D40,
+        0xFF01,
+        0x3FC0,
+        0x3E80,
+        0xFE41,
+        0xFA01,
+        0x3AC0,
+        0x3B80,
+        0xFB41,
+        0x3900,
+        0xF9C1,
+        0xF881,
+        0x3840,
+        0x2800,
+        0xE8C1,
+        0xE981,
+        0x2940,
+        0xEB01,
+        0x2BC0,
+        0x2A80,
+        0xEA41,
+        0xEE01,
+        0x2EC0,
+        0x2F80,
+        0xEF41,
+        0x2D00,
+        0xEDC1,
+        0xEC81,
+        0x2C40,
+        0xE401,
+        0x24C0,
+        0x2580,
+        0xE541,
+        0x2700,
+        0xE7C1,
+        0xE681,
+        0x2640,
+        0x2200,
+        0xE2C1,
+        0xE381,
+        0x2340,
+        0xE101,
+        0x21C0,
+        0x2080,
+        0xE041,
+        0xA001,
+        0x60C0,
+        0x6180,
+        0xA141,
+        0x6300,
+        0xA3C1,
+        0xA281,
+        0x6240,
+        0x6600,
+        0xA6C1,
+        0xA781,
+        0x6740,
+        0xA501,
+        0x65C0,
+        0x6480,
+        0xA441,
+        0x6C00,
+        0xACC1,
+        0xAD81,
+        0x6D40,
+        0xAF01,
+        0x6FC0,
+        0x6E80,
+        0xAE41,
+        0xAA01,
+        0x6AC0,
+        0x6B80,
+        0xAB41,
+        0x6900,
+        0xA9C1,
+        0xA881,
+        0x6840,
+        0x7800,
+        0xB8C1,
+        0xB981,
+        0x7940,
+        0xBB01,
+        0x7BC0,
+        0x7A80,
+        0xBA41,
+        0xBE01,
+        0x7EC0,
+        0x7F80,
+        0xBF41,
+        0x7D00,
+        0xBDC1,
+        0xBC81,
+        0x7C40,
+        0xB401,
+        0x74C0,
+        0x7580,
+        0xB541,
+        0x7700,
+        0xB7C1,
+        0xB681,
+        0x7640,
+        0x7200,
+        0xB2C1,
+        0xB381,
+        0x7340,
+        0xB101,
+        0x71C0,
+        0x7080,
+        0xB041,
+        0x5000,
+        0x90C1,
+        0x9181,
+        0x5140,
+        0x9301,
+        0x53C0,
+        0x5280,
+        0x9241,
+        0x9601,
+        0x56C0,
+        0x5780,
+        0x9741,
+        0x5500,
+        0x95C1,
+        0x9481,
+        0x5440,
+        0x9C01,
+        0x5CC0,
+        0x5D80,
+        0x9D41,
+        0x5F00,
+        0x9FC1,
+        0x9E81,
+        0x5E40,
+        0x5A00,
+        0x9AC1,
+        0x9B81,
+        0x5B40,
+        0x9901,
+        0x59C0,
+        0x5880,
+        0x9841,
+        0x8801,
+        0x48C0,
+        0x4980,
+        0x8941,
+        0x4B00,
+        0x8BC1,
+        0x8A81,
+        0x4A40,
+        0x4E00,
+        0x8EC1,
+        0x8F81,
+        0x4F40,
+        0x8D01,
+        0x4DC0,
+        0x4C80,
+        0x8C41,
+        0x4400,
+        0x84C1,
+        0x8581,
+        0x4540,
+        0x8701,
+        0x47C0,
+        0x4680,
+        0x8641,
+        0x8201,
+        0x42C0,
+        0x4380,
+        0x8341,
+        0x4100,
+        0x81C1,
+        0x8081,
+        0x4040,
+    ]
+    crc = 0
+    for dat in data:
+        tmp = (0xFF & crc) ^ dat  # only last 16 bits of `crc`!
+        crc = (crc >> 8) ^ crc16tab[tmp]
+    return crc

--- a/tests/test_comet/test_cito_plus_1310.py
+++ b/tests/test_comet/test_cito_plus_1310.py
@@ -40,7 +40,7 @@ def test_name():
 
 def test_forward_power():
     """Read forward power from instrument."""
-    cmd = bytes([0x0A, 0x41, 0x1F, 0x56, 0x00, 0x01])
+    cmd = bytes([0x0A, 0x41, 0x1F, 0x55, 0x00, 0x01])
     cmd = add_checksum(cmd)
     answ = bytes([0x0A, 0x41, 0x04, 0x00, 0x00, 0x03, 0xE8])  # 1000 W
     answ = add_checksum(answ)
@@ -50,7 +50,22 @@ def test_forward_power():
         [answ],
         sep="",
     ) as cito:
-        assert cito.forward_power == 1000 * u.W
+        assert cito.forward_power == 1000 * u.mW
+
+
+def test_load_power():
+    """Read forward power from instrument."""
+    cmd = bytes([0x0A, 0x41, 0x1F, 0x57, 0x00, 0x01])
+    cmd = add_checksum(cmd)
+    answ = bytes([0x0A, 0x41, 0x04, 0x00, 0x00, 0x03, 0xE8])  # 1000 W
+    answ = add_checksum(answ)
+    with expected_protocol(
+        ik.comet.CitoPlus1310,
+        [cmd],
+        [answ],
+        sep="",
+    ) as cito:
+        assert cito.load_power == 1000 * u.mW
 
 
 def test_output_power():
@@ -77,9 +92,23 @@ def test_output_power():
         assert cito.output_power == 1 * u.kW
 
 
+@given(pow=st.floats(min_value=0, max_value=1.0, exclude_max=True))
+def test_output_power_smaller_one(pow):
+    """Set output power values smaller than 1 W are set to zero."""
+    cmd_set_0W = bytes([0x0A, 0x42, 0x04, 0xB6, 0x00, 0x00, 0x00, 0x00])
+    cmd_set_0W = add_checksum(cmd_set_0W)
+    with expected_protocol(
+        ik.comet.CitoPlus1310,
+        [cmd_set_0W],
+        [cmd_set_0W],
+        sep="",
+    ) as cito:
+        cito.output_power = pow * u.W
+
+
 def test_reflected_power():
     """Read reflected power from instrument."""
-    cmd = bytes([0x0A, 0x41, 0x1F, 0x55, 0x00, 0x01])
+    cmd = bytes([0x0A, 0x41, 0x1F, 0x56, 0x00, 0x01])
     cmd = add_checksum(cmd)
     answ = bytes([0x0A, 0x41, 0x04, 0x00, 0x00, 0x03, 0xE8])  # 1000 W
     answ = add_checksum(answ)
@@ -89,7 +118,7 @@ def test_reflected_power():
         [answ],
         sep="",
     ) as cito:
-        assert cito.reflected_power == 1000 * u.W
+        assert cito.reflected_power == 1000 * u.mW
 
 
 def test_regulation_mode():

--- a/tests/test_comet/test_cito_plus_1310.py
+++ b/tests/test_comet/test_cito_plus_1310.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python
+"""Test the Comet Cito Plus 1310 instrument."""
+
+from hypothesis import given, strategies as st
+import pytest
+
+import instruments as ik
+from instruments.comet.cito_plus_1310 import _crc16 as crc16
+from instruments.units import ureg as u
+from tests import expected_protocol
+
+
+def add_checksum(data: bytes) -> bytes:
+    """Add a CRC-16 checksum to the data."""
+    checksum = crc16(data)
+    return data + checksum.to_bytes(2, "little")
+
+
+# TEST CLASS PROPERTIES #
+
+
+def test_name():
+    """Get the instrument label as string."""
+    label_exp = "Comet Cito Plus 1310"
+    lbl_bytes = label_exp.encode("utf_8")
+
+    cmd = bytes([0x0A, 0x41, 0x00, 0x0A, 0x00, 0x01])
+    cmd = add_checksum(cmd)
+    answ = bytes([0x0A, 0x41, len(lbl_bytes)]) + lbl_bytes
+    answ = add_checksum(answ)
+
+    with expected_protocol(
+        ik.comet.CitoPlus1310,
+        [cmd],
+        [answ],
+        sep="",
+    ) as cito:
+        assert cito.name == label_exp
+
+
+def test_forward_power():
+    """Read forward power from instrument."""
+    cmd = bytes([0x0A, 0x41, 0x1F, 0x56, 0x00, 0x01])
+    cmd = add_checksum(cmd)
+    answ = bytes([0x0A, 0x41, 0x04, 0x00, 0x00, 0x03, 0xE8])  # 1000 W
+    answ = add_checksum(answ)
+    with expected_protocol(
+        ik.comet.CitoPlus1310,
+        [cmd],
+        [answ],
+        sep="",
+    ) as cito:
+        assert cito.forward_power == 1000 * u.W
+
+
+def test_output_power():
+    """Get/set output power."""
+    cmd_set_1kW = bytes([0x0A, 0x42, 0x04, 0xB6, 0x00, 0x0F, 0x42, 0x40])
+    cmd_set_1kW = add_checksum(cmd_set_1kW)
+    cmd_query = bytes([0x0A, 0x41, 0x04, 0xB6, 0x00, 0x01])
+    cmd_query = add_checksum(cmd_query)
+    answ_1kW = bytes([0x0A, 0x41, 0x04, 0x00, 0x0F, 0x42, 0x40])
+    answ_1kW = add_checksum(answ_1kW)
+    with expected_protocol(
+        ik.comet.CitoPlus1310,
+        [
+            cmd_set_1kW,
+            cmd_query,
+        ],
+        [
+            cmd_set_1kW,
+            answ_1kW,
+        ],
+        sep="",
+    ) as cito:
+        cito.output_power = 1 * u.kW
+        assert cito.output_power == 1 * u.kW
+
+
+def test_reflected_power():
+    """Read reflected power from instrument."""
+    cmd = bytes([0x0A, 0x41, 0x1F, 0x55, 0x00, 0x01])
+    cmd = add_checksum(cmd)
+    answ = bytes([0x0A, 0x41, 0x04, 0x00, 0x00, 0x03, 0xE8])  # 1000 W
+    answ = add_checksum(answ)
+    with expected_protocol(
+        ik.comet.CitoPlus1310,
+        [cmd],
+        [answ],
+        sep="",
+    ) as cito:
+        assert cito.reflected_power == 1000 * u.W
+
+
+def test_regulation_mode():
+    """Set/get the regulation mode."""
+    cmd_forward_power = bytes([0x0A, 0x42, 0x04, 0xB1, 0x00, 0x00, 0x00, 0x00])
+    cmd_forward_power = add_checksum(cmd_forward_power)
+    cmd_load_power = bytes([0x0A, 0x42, 0x04, 0xB1, 0x00, 0x00, 0x00, 0x01])
+    cmd_load_power = add_checksum(cmd_load_power)
+    cmd_read_mode = bytes([0x0A, 0x41, 0x04, 0xB1, 0x00, 0x01])
+    cmd_read_mode = add_checksum(cmd_read_mode)
+    answ_forward_power = bytes([0x0A, 0x41, 0x04, 0x00, 0x00, 0x00, 0x00])
+    answ_forward_power = add_checksum(answ_forward_power)
+    answ_load_power = bytes([0x0A, 0x41, 0x04, 0x00, 0x00, 0x00, 0x01])
+    answ_load_power = add_checksum(answ_load_power)
+
+    with expected_protocol(
+        ik.comet.CitoPlus1310,
+        [
+            cmd_forward_power,
+            cmd_read_mode,
+            cmd_load_power,
+            cmd_read_mode,
+        ],
+        [
+            cmd_forward_power,
+            answ_forward_power,
+            cmd_load_power,
+            answ_load_power,
+        ],
+        sep="",
+    ) as cito:
+        cito.regulation_mode = cito.RegulationMode.ForwardPower
+        assert cito.regulation_mode == cito.RegulationMode.ForwardPower
+        cito.regulation_mode = cito.RegulationMode.LoadPower
+        assert cito.regulation_mode == cito.RegulationMode.LoadPower
+
+
+def test_rf():
+    """Set/get the RF state."""
+    cmd_rf_on = bytes([0x0A, 0x42, 0x03, 0xE9, 0x00, 0x00, 0x00, 0x01])
+    cmd_rf_on = add_checksum(cmd_rf_on)
+    cmd_rf_off = bytes([0x0A, 0x42, 0x03, 0xE9, 0x00, 0x00, 0x00, 0x00])
+    cmd_rf_off = add_checksum(cmd_rf_off)
+    query_rf = bytes([0x0A, 0x41, 0x1F, 0x40, 0x00, 0x01])
+    query_rf = add_checksum(query_rf)
+    answ_rf_on = bytes([0x0A, 0x41, 0x04, 0x00, 0x00, 0x00, 0x00])
+    answ_rf_on = add_checksum(answ_rf_on)
+    answ_rf_off = bytes([0x0A, 0x41, 0x04, 0x00, 0x00, 0x00, 0x01])
+    answ_rf_off = add_checksum(answ_rf_off)
+    with expected_protocol(
+        ik.comet.CitoPlus1310,
+        [
+            cmd_rf_on,
+            query_rf,
+            cmd_rf_off,
+            query_rf,
+        ],
+        [
+            cmd_rf_on,
+            answ_rf_on,
+            cmd_rf_off,
+            answ_rf_off,
+        ],
+        sep="",
+    ) as rf:
+        rf.rf = True
+        assert rf.rf
+        rf.rf = False
+        assert not rf.rf
+
+
+def test_checksum_error_return_package():
+    """Raise an OSError if the checksum of returned package is invalid."""
+    query_rf = bytes([0x0A, 0x41, 0x1F, 0x40, 0x00, 0x01])
+    query_rf = add_checksum(query_rf)
+    answ_rf_on = bytes([0x0A, 0x41, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+
+    with expected_protocol(
+        ik.comet.CitoPlus1310,
+        [query_rf],
+        [answ_rf_on],
+        sep="",
+    ) as rf:
+        with pytest.raises(OSError) as err:
+            _ = rf.rf
+        assert "CRC-16 checksum of returned package does not match" in err.value.args[0]
+
+
+def test_unknown_parameter():
+    """Raise an excpetion if illegal function code used."""
+    cmd = bytes([0x0A, 0x41, 0x00, 0x00])
+    cmd = add_checksum(cmd)
+    answ = bytes([0x0A, 0xC1, 0x01])
+    answ = add_checksum(answ)
+    with expected_protocol(
+        ik.comet.CitoPlus1310,
+        [cmd],
+        [answ],
+        sep="",
+    ) as cito:
+        with pytest.raises(OSError) as err:
+            cito.query(cmd)
+        assert "Unknown parameter or illegal function code" in err.value.args[0]
+
+
+def test_write_answer_package_no_match():
+    """Raise exception if answer package of a write command does not match."""
+    cmd_rf_on = bytes([0x0A, 0x42, 0x03, 0xE9, 0x00, 0x00, 0x00, 0x01])
+    cmd_rf_on = add_checksum(cmd_rf_on)
+    wrong_return = bytes([0x0A, 0x42, 0x04, 0xE9, 0x00, 0x00, 0x00, 0x01])
+    wrong_return = add_checksum(wrong_return)
+
+    with expected_protocol(
+        ik.comet.CitoPlus1310,
+        [cmd_rf_on],
+        [wrong_return],
+        sep="",
+    ) as rf:
+        with pytest.raises(OSError) as err:
+            rf.rf = True
+        assert "Received package does not match sent package" in err.value.args[0]
+
+
+### TEST CHECKSUM FUNCTION ###
+
+
+@pytest.mark.parametrize(
+    "inp_out", [[bytes([0x00]), 0x0000], [bytes([0x31, 0xAE]), 0x2C94]]
+)
+def test_crc16(inp_out):
+    """Test CRC16 calculation with some hand-calculated examples."""
+    input, expected = inp_out
+    assert crc16(input) == expected


### PR DESCRIPTION
This PR adds support for the [Comet Cito Plus 1310 RF generator](https://pct.comet.tech/en/products/rf-generators/cito-plus). It includes:

- Instrument support for the most common / important commands (probably fairly subjective), which includes a command builder and instrument querying
- Test suite
- Docs and examples (API)

Likely, this should also work for the regular Cito 1310 generator and others.
Incorporating additional commands should be simple by following the laid out structure.