### PR TITLE
Bug fixes for Comet and Dressler RF generator

### DIFF
--- a/src/instruments/abstract_instruments/instrument.py
+++ b/src/instruments/abstract_instruments/instrument.py
@@ -472,6 +472,7 @@ class Instrument:
         serial_number=None,
         timeout=3,
         write_timeout=3,
+        **kwargs,
     ):
         """
         Opens an instrument, connecting via a physical or emulated serial port.
@@ -498,6 +499,8 @@ class Instrument:
             instrument before timing out.
         :param float write_timeout: Number of seconds to wait when writing to the
             instrument before timing out.
+        :param kwargs: Additional keyword arguments that will be passed on to
+            serial, e.g., `parity`.
 
         :rtype: `Instrument`
         :return: Object representing the connected instrument.
@@ -555,7 +558,7 @@ class Instrument:
             )
 
         ser = serial_manager.new_serial_connection(
-            port, baud=baud, timeout=timeout, write_timeout=write_timeout
+            port, baud=baud, timeout=timeout, write_timeout=write_timeout, **kwargs
         )
         return cls(ser)
 

--- a/src/instruments/comet/cito_plus_1310.py
+++ b/src/instruments/comet/cito_plus_1310.py
@@ -6,8 +6,6 @@
 from enum import IntEnum
 from typing import Union
 
-import serial
-
 from instruments.abstract_instruments import Instrument
 from instruments.units import ureg as u
 from instruments.util_fns import assume_units
@@ -23,11 +21,19 @@ class CitoPlus1310(Instrument):
     and that, according to the manual, communication over TCP/IP is
     different.
 
+    Important: Make sure that the correct parity is set in the instrument
+    and when calling the instrument. The default seems to be even parity.
+    Below example used even parity for the communication.
+    In general, all communication parameters (baud rate, parity, etc.) can
+    be set in the instrument itself. Below example just shows one possible
+    configuration.
+
     Example:
+        >>> import serial
         >>> import instruments as ik
         >>> port = '/dev/ttyUSB0'
-        >>> baud = 15200
-        >>> inst = ik.comet.CitoPlus1310.open_serial(port, baud)
+        >>> baud = 115200
+        >>> inst = ik.comet.CitoPlus1310.open_serial(port, baud, parity=serial.PARITY_EVEN)
         >>> inst.rf  # query RF state
         False
         >>> inst.rf = True  # turn on RF
@@ -42,7 +48,6 @@ class CitoPlus1310(Instrument):
 
     def __init__(self, filelike):
         super().__init__(filelike)
-        self._file.parity = serial.PARITY_EVEN
 
         self._address = 0x0A
 

--- a/src/instruments/dressler/cesar_1312.py
+++ b/src/instruments/dressler/cesar_1312.py
@@ -5,8 +5,6 @@
 from enum import IntEnum
 from typing import List, Tuple, Union
 
-import serial
-
 from instruments.abstract_instruments import Instrument
 from instruments.units import ureg as u
 from instruments.util_fns import assume_units
@@ -19,8 +17,9 @@ class Cesar1312(Instrument):
 
     Various connection options are available for different models.
     This driver has been tested using the RS-232 option.
-    Upon initialization, the instrument is automatically put into
-    odd parity communication mode (as required by the device).
+    The instrument for which this driver was tested required
+    odd parity mode. You must provide the correct parity for your
+    device when opening the serial connection.
 
     Note that you must set the control mode to `ControlMode.Host`
     in order to send any commands from the computer to the device.
@@ -30,7 +29,7 @@ class Cesar1312(Instrument):
         >>> import instruments as ik
         >>> port = '/dev/ttyUSB0'
         >>> baud = 115200
-        >>> inst = ik.dressler.Cesar1312.open_serial(port, baud)
+        >>> inst = ik.dressler.Cesar1312.open_serial(port, baud, parity=serial.PARITY_ODD)
         >>> inst.control_mode = inst.ControlMode.Host
         >>> inst.rf  # query RF state
         False
@@ -53,8 +52,6 @@ class Cesar1312(Instrument):
 
     def __init__(self, filelike):
         super().__init__(filelike)
-
-        self._file.parity = serial.PARITY_ODD
 
         self._retries = 3
 


### PR DESCRIPTION
I noticed a few things that I didn't do cleanly in these classes, so here are a couple of fixes. This corrects typos in the docstring, but also the following:

Non standard parities for the serial communication is used in these devices. So far I set this in the `__init__` of the class, however, I rapidly noticed that this is a terrible idea as it limits the driver to be only via RS232. Connecting the instrument via, e.g., an RS232 to ethernet converter (i.e., using a MOXA) would not work and throw an error. So here's a fix for that:
- Remove the call to serial in the initialization
- Rather allow user additional `**kwargs` when opening serial and pass these optional ones to creating the serial communicator. This allows to set `parity`, etc.
- Document this better in the drivers, plus in the instrument class itself.