### PR TITLE
Depend on standard-xdrlib if >= Py 3.13

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     pyvisa>=1.9
     ruamel.yaml>=0.18
     typing_extensions>=4.0.1
+    standard-xdrlib;python_version>=3.13
 
 [options.extras_require]
 numpy = numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     pyvisa>=1.9
     ruamel.yaml>=0.18
     typing_extensions>=4.0.1
-    standard-xdrlib;python_version>=3.13
+    standard-xdrlib;python_version>='3.13'
 
 [options.extras_require]
 numpy = numpy


### PR DESCRIPTION
https://github.com/instrumentkit/InstrumentKit/issues/429

Addresses `python-pyvxi11` dependency on system package `xdrlib`, which has been removed in Py3.13