### PR TITLE
Change __repr__ of abstract communicator to be always representable

### DIFF
--- a/src/instruments/abstract_instruments/comm/abstract_comm.py
+++ b/src/instruments/abstract_instruments/comm/abstract_comm.py
@@ -5,7 +5,6 @@ Provides an abstract base class for file-like communication layer classes
 
 # IMPORTS ####################################################################
 
-
 import abc
 import codecs
 import logging
@@ -37,9 +36,11 @@ class AbstractCommunicator(metaclass=abc.ABCMeta):
     # FORMATTING METHODS #
 
     def __repr__(self):
-        return "<{} object at 0x{:X} " "connected to {}>".format(
-            type(self).__name__, id(self), repr(self.address)
-        )
+        try:
+            addr = repr(self.address)
+        except:  # noqa: E722
+            addr = "unknown"
+        return f"<{type(self).__name__} object at 0x{id(self):X} connected to {addr}>"
 
     # CONCRETE PROPERTIES #
 


### PR DESCRIPTION
I've been working on this as well, thus a creative PR for a change ;) 
Here's a fix for the last of your py3.13 issues (after this, it's only a bunch of warnings).

The tests that fail without this are the ones that fail out of the class before a connection is built up. I think when throwing the error, as no `self._conn` exists, no `self.address` can exist and an error is thrown (but not the correct one we are testing for) when python tries to print the error message. Well, this is my feeling, I have not really gone deep enough down the rabbit hole to find any of this behavior in the changelog for py3.13...