### PR TITLE
Fix the open_tcpip bug that crept in with the `auth` argument

### DIFF
--- a/src/instruments/abstract_instruments/instrument.py
+++ b/src/instruments/abstract_instruments/instrument.py
@@ -457,7 +457,10 @@ class Instrument:
         conn = socket.socket()
         conn.connect((host, port))
 
-        ret_cls = cls(SocketCommunicator(conn), auth=auth)
+        if auth is None:
+            ret_cls = cls(SocketCommunicator(conn))
+        else:
+            ret_cls = cls(SocketCommunicator(conn), auth=auth)
 
         return ret_cls
 

--- a/src/instruments/yokogawa/yokogawa6370.py
+++ b/src/instruments/yokogawa/yokogawa6370.py
@@ -43,15 +43,14 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
     >>> inst = ik.yokogawa.Yokogawa6370.open_tcpip("192.168.0.35", 10001, auth=auth)
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, filelike, auth=None):
+        super().__init__(filelike)
         self._channel_count = len(self.Traces)
 
         if isinstance(self._file, SocketCommunicator):
             self.terminator = "\r\n"  # TCP IP connection terminator
 
-        # Authenticate with `auth` (supplied as keyword argument) if provided
-        auth = kwargs.get("auth", None)
+        # Authenticate with `auth`
         if auth is not None:
             self._authenticate(auth)
 


### PR DESCRIPTION
This fixes the bug discussed in #439 and adds a test that fails because of this issue.

Now, the variable `auth` in `.open_tcpip` classmethod is only passed on to the instrument class itself it is not `None`, which is the default value. 

I also corrected the initialization of the Yokogawa 6370. This one is now consistent with the rest of the instruments and does not accept `args`, `kwargs` anymore, but still does accept `auth`. All tests for the Yokogawa 6370 still pass.

*Note*: I will double check this as well with an actual instrument that has failed so far due to this error and confirm that it works now (assuming it does).

Closes #439 