### PR TITLE
Add support Pfeiffer TPG36x Vaccuum Gauge Controller

### DIFF
--- a/doc/source/apiref/index.rst
+++ b/doc/source/apiref/index.rst
@@ -29,6 +29,7 @@ Contents:
     newport
     ondax
     oxford
+    pfeiffer
     phasematrix
     picowatt
     qubitekk

--- a/doc/source/apiref/pfeiffer.rst
+++ b/doc/source/apiref/pfeiffer.rst
@@ -1,0 +1,12 @@
+.. currentmodule:: instruments.pfeiffer
+
+===========================
+Pfeiffer Vacuum Instruments
+===========================
+
+:class:`TPG36x` Vacuum Gauge Controller
+=======================================
+
+.. autoclass:: TPG36x
+    :members:
+    :undoc-members:

--- a/src/instruments/__init__.py
+++ b/src/instruments/__init__.py
@@ -28,6 +28,7 @@ from . import minghe
 from . import newport
 from . import oxford
 from . import phasematrix
+from . import pfeiffer
 from . import picowatt
 from . import qubitekk
 from . import rigol

--- a/src/instruments/pfeiffer/__init__.py
+++ b/src/instruments/pfeiffer/__init__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+"""
+Module containing Pfeiffer instruments
+"""
+
+
+from .tpg36x import TPG36x

--- a/src/instruments/pfeiffer/tpg36x.py
+++ b/src/instruments/pfeiffer/tpg36x.py
@@ -22,9 +22,11 @@ class TPG36x(Instrument):
     version (TPG361), set the `number_channels` property to 1.
 
     Example usage:
-
-        TODO:
-
+        >>> import instruments as ik
+        >>> inst = ik.pfeiffer.TPG36x.open_serial("/dev/ttyUSB0", 9600)
+        >>> ch = inst.channel[0]
+        >>> ch.pressure
+        0.02 * u.mbar
     """
 
     def __init__(self, filelike):
@@ -55,7 +57,7 @@ class TPG36x(Instrument):
         FRENCH = 2
 
     class Unit(Enum):
-        """Enum for the pressure units (example)."""
+        """Enum for the pressure units."""
 
         MBAR = 0
         TORR = 1
@@ -97,6 +99,13 @@ class TPG36x(Instrument):
 
             :return: Pressure on given channel.
             :rtype: `u.Quantity`
+
+            Example:
+                >>> import instruments as ik
+                >>> inst = ik.pfeiffer.TPG36x.open_serial("/dev/ttyUSB0", 9600)
+                >>> ch = inst.channel[0]
+                >>> ch.pressure
+                0.02 * u.mbar
             """
             status_msgs = {
                 0: "OK",
@@ -127,6 +136,13 @@ class TPG36x(Instrument):
 
             :return: The status of the sensor.
             :rtype: `TPG36x.Channel.SensorStatus`
+
+            Example:
+                >>> import instruments as ik
+                >>> inst = ik.pfeiffer.TPG36x.open_serial("/dev/ttyUSB0", 9600)
+                >>> ch = inst.channel[0]
+                >>> ch.status
+                SensorStatus.ON
             """
             val = self._parent.query("SEN")
             val = int(val.split(",")[self._chan])
@@ -151,6 +167,11 @@ class TPG36x(Instrument):
         Note that the channel number is pythonic, i.e., the first channel is 0.
 
         :rtype: `TPG36x.Channel`
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.pfeiffer.TPG36x.open_serial("/dev/ttyUSB0", 9600)
+            >>> ch = inst.channel[0]
         """
         return ProxyList(self, self.Channel, range(self._number_channels))
 
@@ -169,6 +190,13 @@ class TPG36x(Instrument):
             1. IP address as string
             2. Subnet mask as string
             3. Gateway as string
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.pfeiffer.TPG36x.open_serial("/dev/ttyUSB0", 9600)
+            >>> inst.ethernet_configuration = [inst.EthernetMode.STATIC, "192.168.1.42", "255.255.255.0", "192.168.1.1"]
+           >>> inst.ethernet_configuration
+            [inst.EthernetMode.STATIC, "192.168.1.42", "255.255.255.0", "192.168.1.1"]
         """
         return_list = self.query("ETH").split(",")
         return_list[0] = self.EthernetMode(int(return_list[0]))
@@ -207,21 +235,21 @@ class TPG36x(Instrument):
     @property
     def language(self):
         """
-        Get the language of the TPG36x.
+        Get/set the language of the TPG36x.
 
         :rtype: `TPG36x.Language`
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.pfeiffer.TPG36x.open_serial("/dev/ttyUSB0", 9600)
+            >>> inst.language
+            Language.ENGLISH
         """
         val = int(self.query("LNG"))
         return self.Language(val)
 
     @language.setter
     def language(self, value):
-        """
-        Set the language of the TPG36x.
-
-        :param value: The language to set.
-        :type value: `TPG36x.Language`
-        """
         self.sendcmd(f"LNG,{value.value}")
 
     @property
@@ -231,6 +259,12 @@ class TPG36x(Instrument):
 
         :return: MAC address of the TPG36x.
         :rtype: str
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.pfeiffer.TPG36x.open_serial("/dev/ttyUSB0", 9600)
+            >>> inst.mac_address
+            "00:1A:2B:3C:4D:5E"
         """
         return self.query("MAC")
 
@@ -240,6 +274,12 @@ class TPG36x(Instrument):
         Get the name from the TPG36x.
 
         :rtype: str
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.pfeiffer.TPG36x.open_serial("/dev/ttyUSB0", 9600)
+            >>> inst.name
+            "TPG 362"
         """
         return self.query("AYT").split(",")[0]
 
@@ -248,7 +288,16 @@ class TPG36x(Instrument):
         """
         The number of channels on the TPG36x.
 
+        This defaults to two channels. Set this to 1 if you have a one gauge
+        instrument, i.e., a TPG361.
+
         :rtype: int
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.pfeiffer.TPG36x.open_serial("/dev/ttyUSB0", 9600)
+            >>> inst.number_channels
+            2
         """
         return self._number_channels
 
@@ -267,16 +316,28 @@ class TPG36x(Instrument):
         method on it.
 
         :rtype: `pint.Quantity`
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.pfeiffer.TPG36x.open_serial("/dev/ttyUSB0", 9600)
+            >>> inst.pressure
+            0.02 * u.mbar
         """
         return self.channel[0].pressure
 
     @property
     def unit(self):
         """
-        Get or set the unit of the TPG36x (global to the instrument).
+        Get/set the unit of the TPG36x (global to the instrument).
 
         :return: The current unit.
         :rtype: `TPG36x.Unit`
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.pfeiffer.TPG36x.open_serial("/dev/ttyUSB0", 9600)
+            >>> inst.unit
+            Unit.MBAR
         """
         val = self.query("UNI")
         val = int(val)

--- a/src/instruments/pfeiffer/tpg36x.py
+++ b/src/instruments/pfeiffer/tpg36x.py
@@ -5,7 +5,7 @@ Driver for the Pfeiffer TPG36x vacumm gauge controller.
 
 # IMPORTS #####################################################################
 
-from enum import Enum, IntEnum
+from enum import Enum
 
 from instruments.abstract_instruments import Instrument
 from instruments.units import ureg as u
@@ -60,6 +60,9 @@ class TPG36x(Instrument):
         MBAR = 0
         TORR = 1
         PASCAL = 2
+        MICRON = 3
+        HPASCAL = 4
+        VOLT = 5
 
     class Channel:
         """
@@ -109,10 +112,11 @@ class TPG36x(Instrument):
             status_str, val_str = raw_str.split(",")
             status = int(status_str)
             val = float(val_str)
-            current_unit = self._parent.unit
 
             if status != 0:
                 raise OSError(status_msgs.get(status, "Unknown error"))
+
+            current_unit = self._parent.unit
 
             return val * u.Quantity(current_unit.name.lower())
 
@@ -194,7 +198,7 @@ class TPG36x(Instrument):
                         raise ValueError(
                             f"Each part of the address {addr} must be between 0 and 255."
                         )
-            except ValueError:
+            except (ValueError, AttributeError):
                 raise ValueError(
                     f"The address {addr} must be a string of 4 numbers separated by dots."
                 )

--- a/src/instruments/pfeiffer/tpg36x.py
+++ b/src/instruments/pfeiffer/tpg36x.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+"""
+Driver for the Pfeiffer TPG36x vacumm gauge controller.
+"""
+
+# IMPORTS #####################################################################
+
+from enum import Enum, IntEnum
+
+from instruments.abstract_instruments import Instrument
+from instruments.units import ureg as u
+from instruments.util_fns import ProxyList
+
+# CLASSES #####################################################################
+
+
+class TPG36x(Instrument):
+    """
+    The Pfeiffer TPG361/2 is a vacuum gauge controller with one/two channels.
+
+    By default, the two channel version is intialized. If you have the one channel
+    version (TPG361), set the `number_channels` property to 1.
+
+    Example usage:
+
+        TODO:
+
+    """
+
+    def __init__(self, filelike):
+        super().__init__(filelike)
+        self._number_channels = 2
+
+    class Channel:
+        """
+        Class representing a sensor attached to the TPG 362.
+
+        .. warning:: This class should NOT be manually created by the user. It is
+            designed to be initialized by the `TPG36x` class.
+        """
+
+        def __init__(self, parent, chan):
+            if not isinstance(parent, TPG36x):
+                raise TypeError("Don't do that.")
+
+            self._parent = parent
+
+        @property
+        def pressure(self):
+            """
+            The pressure measured by the channel.
+
+            :rtype: `pint.Quantity`
+            """
+            # TODO: Implement this!
+            pass
+
+    @property
+    def channel(self):
+        """
+        Gets a specific channel object.
+
+        Note that the channel number is pythonic, i.e., the first channel is 0.
+
+        :rtype: `TPG36x.Channel`
+        """
+        return ProxyList(self, self.Channel, TPG36x.Channels)
+
+    @property
+    def name(self):
+        """
+        Get the name from the TPG36x.
+
+        :rtype: str
+        """
+        # TODO: Implement this.
+        pass
+
+    @property
+    def number_channels(self):
+        """
+        The number of channels on the TPG36x.
+
+        :rtype: int
+        """
+        return self._number_channels
+
+    @number_channels.setter
+    def number_channels(self, value):
+        if value not in (1, 2):
+            raise ValueError("The TPG36x only supports 1 or 2 channels.")
+        self._number_channels = value
+
+    @property
+    def pressure(self):
+        """
+        The pressure measured by the first channel.
+
+        To select the channel, get a channel first and then call the pressure
+        method on it.
+
+        :rtype: `pint.Quantity`
+        """
+        return self.channel[0].pressure

--- a/tests/test_pfeiffer/test_tpg36x.py
+++ b/tests/test_pfeiffer/test_tpg36x.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python
+"""
+Module containing tests for the TPG 36x gauge controller
+"""
+
+# IMPORTS ####################################################################
+
+import pytest
+
+import instruments as ik
+from instruments.units import ureg as u
+from tests import expected_protocol, unit_eq
+
+# TESTS ######################################################################
+
+# pylint: disable=no-member,protected-access
+
+SEP = "\r\n"
+ENQ = chr(5)
+ACK = chr(6)
+NAK = chr(21)
+
+# CHANNELS #
+
+
+def test_tpg36x_channel_init():
+    """Ensure an error is raised when not coming from correct class."""
+    with pytest.raises(TypeError):
+        ik.pfeiffer.TPG36x.Channel(42, 0)
+
+
+def test_tpg36x_channel_pressure():
+    """Get the pressure from the device."""
+    with expected_protocol(
+        ik.pfeiffer.TPG36x,
+        ["PR1", SEP, ENQ, "UNI", SEP, ENQ],
+        [ACK, SEP, "0,2.0000E-2", SEP, ACK, SEP, "0", SEP],
+        sep="",
+    ) as tpg:
+        ch = tpg.channel[0]
+        assert ch.pressure == 0.02 * u.mbar
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        [1, "Underrange"],
+        [2, "Overrange"],
+        [3, "Sensor error"],
+        [4, "Sensor off"],
+        [5, "No sensor"],
+        [6, "Identification error"],
+        [42, "Unknown error"],
+    ],
+)
+def test_tpg36x_channel_pressure_error(status):
+    """Raise correct error if statos is not zero."""
+    err_code, err_meaning = status
+    with expected_protocol(
+        ik.pfeiffer.TPG36x,
+        ["PR1", SEP, ENQ],
+        [ACK, SEP, f"{err_code},2.0000E-2", SEP],
+        sep="",
+    ) as tpg:
+        ch = tpg.channel[0]
+        with pytest.raises(OSError) as err:
+            ch.pressure
+            assert err.value.args[0].contains(err_meaning)
+
+
+def test_tpg36x_channel_status():
+    """Set/get the status of a channel."""
+    with expected_protocol(
+        ik.pfeiffer.TPG36x,
+        ["SEN", SEP, ENQ, "SEN,0,2", SEP, "SEN", SEP, ENQ],
+        [ACK, SEP, "0,1", SEP, ACK, SEP, ACK, SEP, "0,2", SEP],
+        sep="",
+    ) as tpg:
+        ch0 = tpg.channel[0]
+        assert ch0.status == ch0.SensorStatus.CANNOT_TURN_ON_OFF
+        ch1 = tpg.channel[1]
+        ch1.status = ch1.SensorStatus.ON
+        assert ch1.status == ch1.SensorStatus.ON
+
+
+def test_tpg36x_channel_status_error():
+    """Raise ValueErrors if bad statuses are given."""
+    with expected_protocol(
+        ik.pfeiffer.TPG36x,
+        [],
+        [],
+        sep="",
+    ) as tpg:
+        ch = tpg.channel[0]
+        with pytest.raises(ValueError):
+            ch.status = 42
+        with pytest.raises(ValueError):
+            ch.status = ch.SensorStatus.CANNOT_TURN_ON_OFF
+
+
+# TPG36x #1
+
+
+def test_tpg36x_ethernet_configuration_static():
+    """Set/get the ethernet configuration."""
+    ip = "192.168.1.10"
+    subnet = "255.255.255.0"
+    gateway = "192.168.1.1"
+    with expected_protocol(
+        ik.pfeiffer.TPG36x,
+        [f"ETH,0,{ip},{subnet},{gateway}", SEP, "ETH", SEP, ENQ],
+        [ACK, SEP, ACK, SEP, f"0,{ip},{subnet},{gateway}", SEP],
+        sep="",
+    ) as tpg:
+        tpg.ethernet_configuration = [
+            tpg.EthernetMode.STATIC,
+            "192.168.1.10",
+            "255.255.255.0",
+            "192.168.1.1",
+        ]
+        mode, ip_rec, subnet_rec, gateway_rec = tpg.ethernet_configuration
+        assert mode == tpg.EthernetMode.STATIC
+        assert ip == ip_rec
+        assert subnet == subnet_rec
+        assert gateway == gateway_rec
+
+
+def test_tpg36x_ethernet_configuration_dhcp():
+    """Set/get the ethernet configuration (static)."""
+    zero_address = "0.0.0.0"
+    with expected_protocol(
+        ik.pfeiffer.TPG36x,
+        [f"ETH,1,{zero_address},{zero_address},{zero_address}", SEP],
+        [ACK, SEP],
+        sep="",
+    ) as tpg:
+        tpg.ethernet_configuration = tpg.EthernetMode.DHCP
+
+
+def test_tpg36x_ethernet_configuration_errors():
+    """Raise appropriate errors for bad settings."""
+    good_addr = "192.168.1.1"
+    with expected_protocol(
+        ik.pfeiffer.TPG36x,
+        [],
+        [],
+        sep="",
+    ) as tpg:
+        with pytest.raises(ValueError):  # invalid list
+            tpg.ethernet_configuration = [tpg.EthernetMode.STATIC, 42]
+        with pytest.raises(ValueError):  # ip address is a number
+            tpg.ethernet_configuration = [
+                tpg.EthernetMode.STATIC,
+                42,
+                good_addr,
+                good_addr,
+            ]
+        with pytest.raises(ValueError):  # incorrect subnet
+            tpg.ethernet_configuration = [
+                tpg.EthernetMode.STATIC,
+                good_addr,
+                "192.169",
+                good_addr,
+            ]
+
+        with pytest.raises(ValueError):  # incorrect gateway
+            tpg.ethernet_configuration = [
+                tpg.EthernetMode.STATIC,
+                good_addr,
+                good_addr,
+                "192.168.1.256",
+            ]
+        with pytest.raises(ValueError):  # first value not an EthernetMode
+            tpg.ethernet_configuration = [42, good_addr, good_addr, good_addr]
+
+
+def test_tpg36x_language():
+    """Set/get the language of the TPG36x."""
+    with expected_protocol(
+        ik.pfeiffer.TPG36x,
+        ["LNG,0", SEP, "LNG", SEP, ENQ],
+        [ACK, SEP, ACK, SEP, "0", SEP],
+        sep="",
+    ) as tpg:
+        tpg.language = tpg.Language.ENGLISH
+        assert tpg.language == tpg.Language.ENGLISH
+
+
+def test_tpg36x_mac_address():
+    """Get the MAC address of the TPG36x."""
+    with expected_protocol(
+        ik.pfeiffer.TPG36x,
+        ["MAC", SEP, ENQ],
+        [ACK, SEP, "00:00:00:00:00:00", SEP],
+        sep="",
+    ) as tpg:
+        assert tpg.mac_address == "00:00:00:00:00:00"
+
+
+def test_tpg36x_mac_address_name():
+    """Get the name from the TPG36x."""
+    with expected_protocol(
+        ik.pfeiffer.TPG36x,
+        ["AYT", SEP, ENQ],
+        [ACK, SEP, "TPG 362,PTG28290,44990000,010100,010100", SEP],
+        sep="",
+    ) as tpg:
+        assert tpg.name == "TPG 362"
+
+
+def test_tpg36x_number_channels():
+    """Set/get the number of channels."""
+    with expected_protocol(
+        ik.pfeiffer.TPG36x,
+        [],
+        [],
+        sep="",
+    ) as tpg:
+        tpg.number_channels = 2
+        assert tpg.number_channels == 2
+
+    with expected_protocol(
+        ik.pfeiffer.TPG36x,
+        [],
+        [],
+        sep="",
+    ) as tpg:
+        tpg.number_channels = 1
+        assert tpg.number_channels == 1
+
+
+@pytest.mark.parametrize("bad_num", [3, 0])
+def test_tpg36x_number_channels_error(bad_num):
+    """Raise ValueErrors if bad number of channels are given."""
+    with expected_protocol(
+        ik.pfeiffer.TPG36x,
+        [],
+        [],
+        sep="",
+    ) as tpg:
+        with pytest.raises(ValueError):
+            tpg.number_channels = bad_num
+
+
+def test_tpg36x_pressure():
+    """Get the pressure from a one-channel device."""
+    with expected_protocol(
+        ik.pfeiffer.TPG36x,
+        ["PR1", SEP, ENQ, "UNI", SEP, ENQ],
+        [ACK, SEP, "0,2.0000E-2", SEP, ACK, SEP, "0", SEP],
+        sep="",
+    ) as tpg:
+        assert tpg.pressure == 0.02 * u.mbar
+
+
+@pytest.mark.parametrize("ret_val", [0, 1, 2, 3, 4, 5])
+def test_tpg36x_unit(ret_val):
+    """Get the unit from the device."""
+    with expected_protocol(
+        ik.pfeiffer.TPG36x,
+        ["UNI", SEP, ENQ],
+        [ACK, SEP, f"{int(ret_val)}", SEP],
+        sep="",
+    ) as tpg:
+        assert tpg.unit == tpg.Unit(ret_val)
+
+
+def test_tpg36x_unit_string():
+    """Set a unit from a string."""
+    with expected_protocol(
+        ik.pfeiffer.TPG36x,
+        ["UNI,0", SEP, "UNI", SEP, ENQ],
+        [ACK, SEP, ACK, SEP, "0", SEP],
+        sep="",
+    ) as tpg:
+        tpg.unit = "mbar"
+        assert tpg.unit == tpg.Unit.MBAR


### PR DESCRIPTION
This PR adds support for the Pfeiffer TPG36x single or dual channel vaccuum gauge controller. 

Instrument communications mainly implemented by @Mathias-koller, I added some test and cleanup.

Tested with a dual gauge controller in lab.