### PR TITLE
Add support for sunpower cryotel gt gen2

### DIFF
--- a/doc/source/apiref/index.rst
+++ b/doc/source/apiref/index.rst
@@ -35,6 +35,7 @@ Contents:
     qubitekk
     rigol
     srs
+    sunpower
     tektronix
     teledyne
     thorlabs

--- a/doc/source/apiref/sunpower.rst
+++ b/doc/source/apiref/sunpower.rst
@@ -1,0 +1,12 @@
+.. currentmodule:: instruments.sunpower
+
+====================
+Sunpower Instruments
+====================
+
+:class:`CryoTelGT` Cryocooler
+=============================
+
+.. autoclass:: CryoTelGT
+    :members:
+    :undoc-members:

--- a/src/instruments/__init__.py
+++ b/src/instruments/__init__.py
@@ -33,6 +33,7 @@ from . import picowatt
 from . import qubitekk
 from . import rigol
 from . import srs
+from . import sunpower
 from . import tektronix
 from . import teledyne
 from . import thorlabs

--- a/src/instruments/sunpower/__init__.py
+++ b/src/instruments/sunpower/__init__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+"""
+Module containing Sunpower instruments
+"""
+
+
+from .cryotel_gt import CryoTelGT

--- a/src/instruments/sunpower/cryotel_gt.py
+++ b/src/instruments/sunpower/cryotel_gt.py
@@ -34,9 +34,9 @@ class CryoTelGT(Instrument):
     Example usage:
         >>> import instruments as ik
         >>> inst = ik.sunpower.CryoTelGT.open_serial("/dev/ttyACM0", 4800)
-        >>> inst.temperature_current
+        >>> inst.temperature
         82.0 Kelvin
-        >>> inst.temperature_set
+        >>> inst.temperature_setpoint
         77.0 Kelvin
     """
 
@@ -244,7 +244,7 @@ class CryoTelGT(Instrument):
         self.query("SET MIN", float(value.magnitude))
 
     @property
-    def power_set(self):
+    def power_setpoint(self):
         """
         Get/set the setpoint power in Watts.
 
@@ -262,8 +262,8 @@ class CryoTelGT(Instrument):
         ret_val = self.query("SET PWOUT")
         return float(ret_val) * u.W
 
-    @power_set.setter
-    def power_set(self, value):
+    @power_setpoint.setter
+    def power_setpoint(self, value):
         value = assume_units(value, u.W).to(u.W)
         if value.magnitude < 0 or value.magnitude > 999.99:
             raise ValueError("Power setpoint must be between 0 and 999.99 Watts.")
@@ -301,7 +301,7 @@ class CryoTelGT(Instrument):
         return float(ret_val) * u.K
 
     @property
-    def temperature_set(self):
+    def temperature_setpoint(self):
         """
         Get/set the setpoint temperature in Kelvin.
 
@@ -314,8 +314,8 @@ class CryoTelGT(Instrument):
         ret_val = self.query("SET TTARGET")
         return float(ret_val) * u.K
 
-    @temperature_set.setter
-    def temperature_set(self, value):
+    @temperature_setpoint.setter
+    def temperature_setpoint(self, value):
         value = assume_units(value, u.K).to(u.K)
         self.query("SET TTARGET", float(value.magnitude))
 

--- a/src/instruments/sunpower/cryotel_gt.py
+++ b/src/instruments/sunpower/cryotel_gt.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python
+"""
+Driver for the Sunpower CryoTel GT generation 2 cryocooler.
+"""
+
+# IMPORTS #####################################################################
+
+import warnings
+
+from enum import Enum
+
+from instruments.abstract_instruments import Instrument
+from instruments.units import ureg as u
+from instruments.util_fns import assume_units
+
+# CLASSES #####################################################################
+
+
+class CryoTelGT(Instrument):
+    """
+    The Sunpower CyroTel GT is a cryocooler.
+
+    This driver is for the GT generation 2. According to the Sunpower website,
+    this means for cryocoolers purchased after May 2012.
+
+    Caution: Do not use this driver to established a closed loop control of the
+    cryocooler, as this may cause malfunction and potentially damage to the
+    device (see the manual for details). You can use this driver however to adjust
+    the setpoint temperature and read the current temperature.
+
+    For communications, the default baudrate is 4800, 8 data bits, 1 stop bit,
+    and no flow control.
+
+    Example usage:
+        >>> import instruments as ik
+        >>> inst = ik.sunpower.CryoTelGT.open_serial("/dev/ttyACM0", 4800)
+        >>> inst.temperature_current
+        82.0 Kelvin
+        >>> inst.temperature_set
+        77.0 Kelvin
+    """
+
+    class ControlMode(Enum):
+        """
+        Control modes for the Cryocooler.
+        """
+
+        POWER = 0
+        TEMPERATURE = 2
+
+    def __init__(self, filelike):
+        super().__init__(filelike)
+
+        self._error_codes = {
+            1: "Over Current",
+            2: "Jumper Error",
+            4: "Serial Error",
+            8: "Non-volatile Memory Error",
+            16: "Watchdog Error",
+            32: "Temperature Sensor Error",
+        }
+
+        self.terminator = "\r"  # FIXME: Unclear if this is correct
+
+    @property
+    def control_mode(self):
+        """
+        Get/set the control mode of the CryoTel GT.
+
+        Valid options are `ControlMode.POWER` and `ControlMode.TEMPERATURE`.
+
+        .. note:: The set control mode will be reset after a power cycle unless you also
+        call the `save_control_mode()` method.
+
+        :return: The current control mode.
+        """
+        ret_val = int(self.query("SET PID"))
+        return self.ControlMode(ret_val)
+
+    @control_mode.setter
+    def control_mode(self, value):
+        if not isinstance(value, self.ControlMode):
+            raise ValueError(
+                "Invalid control mode. Use ControlMode.POWER or ControlMode.TEMPERATURE."
+            )
+        self.query("SET PID", value.value)
+
+    @property
+    def power_current(self):
+        """
+        Get the current power in Watts.
+
+        :return: The current power in Watts.
+        """
+        ret_val = self.query("P")
+        return float(ret_val) * u.W
+
+    @property
+    def power_current_and_limits(self):
+        """
+        Get the current power and power limits in Watts.
+
+        :return: Three u.Quantity objects representing the maximum allowable power at the
+            current temperature, the minimum allowable power at the current temperature,
+            and the current power.
+        """
+        ret_vals = self.query_multiline("E", 3)
+        max_power = float(ret_vals[0]) * u.W
+        min_power = float(ret_vals[1]) * u.W
+        current_power = float(ret_vals[2]) * u.W
+        return max_power, min_power, current_power
+
+    @property
+    def power_set(self):
+        """
+        Get/set the setpoint power in Watts.
+
+        This setpoint is used when the control mode is set to `ControlMode.POWER`.
+        Setting the power is unitful. If no unit is given, it is assumed
+        to be in Watts.
+
+        While any number from 0 to 999.99 can be set, the controller will only command
+        a power that will not damage the cryocooler.
+
+        :return: The setpoint power in Watts.
+
+        :raises ValueError: If the power is set to a value outside the allowed range.
+        """
+        ret_val = self.query("SET PWOUT")
+        return float(ret_val) * u.W
+
+    @power_set.setter
+    def power_set(self, value):
+        value = assume_units(value, u.W).to(u.W)
+        if value.magnitude < 0 or value.magnitude > 999.99:
+            raise ValueError("Power setpoint must be between 0 and 999.99 Watts.")
+        self.query("SET PWOUT", value.magnitude)
+
+    @property
+    def serial_number(self):
+        """
+        Get the serial number of the CryoTel GT.
+
+        :return: The serial number as a string.
+        """
+        return self.query("SERIAL")
+
+    @property
+    def state(self):
+        """
+        Get a list of most of the control parameters and their values.
+
+        Note: This is the direct list from the CryoTel GT controller. See the manual for
+        the meaning of the parameters.
+
+        :return: A list of strings representing the control parameters and their values.
+        """
+        return self.query_multiline("STATE", 14)
+
+    @property
+    def temperature_current(self):
+        """
+        Get the current temperature in Kelvin.
+
+        :return: The current temperature in Kelvin.
+        """
+        ret_val = self.query("TC")
+        return float(ret_val) * u.K
+
+    @property
+    def temperature_set(self):
+        """
+        Get/set the setpoint temperature in Kelvin.
+
+        This setpoint is used when the control mode is set to `ControlMode.TEMPERATURE`.
+        Setting the temperature is unitful. If no unit is given, it is assumed
+        to be in Kelvin.
+
+        :return: The setpoint temperature in Kelvin.
+        """
+        ret_val = self.query("SET TTARGET")
+        return float(ret_val) * u.K
+
+    @temperature_set.setter
+    def temperature_set(self, value):
+        value = assume_units(value, u.K).to(u.K)
+        self.query("SET TTARGET", value.magnitude)
+
+    # CryoCooler Methods
+
+    def reset(self):
+        """
+        Reset the CryoTel GT to factory defaults.
+        """
+        _ = self.query_multiline("RESET=F", 2)
+
+    def save_control_mode(self):
+        """
+        Save the current control mode as the default control mode.
+        """
+        _ = self.query("SAVE PID")
+
+    # Driver methods
+
+    def query(self, command, value=None):
+        """
+        Send a query to the cooler and return the response if no value is given.
+
+        When setting a variable, the CryoTel GT will generally return the value
+        that was set. This is checked for accuracy and a warning is raised if the
+        return value is not the same as the set value.
+
+        For an actual query where we expect a result, the result is returned unchanged.
+
+        :param command: The command to send to the cooler.
+        :param value: The value to be set. If not given or None, it is assumed that
+            you want to query the cryocooler.
+
+        :return: The response from the cooler or None.
+        """
+        if value is None:
+            self.sendcmd(command)
+            return self.read()
+        else:
+            if isinstance(value, float):
+                value_to_send = f"{value:.2f}"
+            else:
+                value_to_send = str(value)
+            self.sendcmd(f"{command}={value_to_send}")
+            ret_val = self.read()
+            if float(ret_val) != value:
+                warnings.warn(
+                    f"Set value {value} does not match returned value {ret_val}."
+                )
+
+    def query_multiline(self, command, num_lines):
+        """
+        Send a query to the cooler and return the response.
+
+        This is used for commands that return multiple lines of data.
+
+        :param command: The command to send to the cooler.
+        :param num_lines: The number of lines to read from the cooler.
+
+        :return: The response from the cooler as a list of lines.
+        """
+        self.sendcmd(command)
+        ret_val = [self.read() for _ in range(num_lines)]
+        return ret_val

--- a/tests/test_sunpower/test_cryotel_gt.py
+++ b/tests/test_sunpower/test_cryotel_gt.py
@@ -50,13 +50,12 @@ def test_errors():
     """Get the error codes of the CryoTel GT and return error strings."""
     with expected_protocol(
         ik.sunpower.CryoTelGT,
-        ["ERROR"],  # , "ERROR", "ERROR"],
-        # ["ERROR", "100000", "ERROR", "000000", "ERROR", "011001"],
-        ["ERROR", "011001"],
+        ["ERROR", "ERROR", "ERROR"],
+        ["ERROR", "100000", "ERROR", "000000", "ERROR", "011001"],
         sep="\r",
     ) as ct:
-        # assert ct.errors == ["Temperature Sensor Error"]
-        # assert ct.errors == []
+        assert ct.errors == ["Temperature Sensor Error"]
+        assert ct.errors == []
         assert ct.errors == [
             "Over Current",
             "Non-volatile Memory Error",
@@ -149,7 +148,7 @@ def test_power_min():
             ct.power_min = -10 * u.W
 
 
-def test_power_set():
+def test_power_setpoint():
     """Get/set the power setpoint of the CryoTel GT."""
     with expected_protocol(
         ik.sunpower.CryoTelGT,
@@ -157,14 +156,14 @@ def test_power_set():
         ["SET PWOUT", "0.00", "SET PWOUT=100.00", "100.00", "SET PWOUT", "100.00"],
         sep="\r",
     ) as ct:
-        assert ct.power_set == 0 * u.W
-        ct.power_set = 100 * u.W
-        assert ct.power_set == 100 * u.W
+        assert ct.power_setpoint == 0 * u.W
+        ct.power_setpoint = 100 * u.W
+        assert ct.power_setpoint == 100 * u.W
 
         with pytest.raises(ValueError):
-            ct.power_set = 1000 * u.W
+            ct.power_setpoint = 1000 * u.W
         with pytest.raises(ValueError):
-            ct.power_set = -10 * u.W
+            ct.power_setpoint = -10 * u.W
 
 
 def test_serial_number():
@@ -217,7 +216,7 @@ def test_temperature():
         assert ct.temperature == 72.89 * u.K
 
 
-def test_temperature_set():
+def test_temperature_setpoint():
     """Get/set the temperature setpoint of the CryoTel GT."""
     with expected_protocol(
         ik.sunpower.CryoTelGT,
@@ -232,9 +231,9 @@ def test_temperature_set():
         ],
         sep="\r",
     ) as ct:
-        assert ct.temperature_set == 0 * u.K
-        ct.temperature_set = 100 * u.K
-        assert ct.temperature_set == 100 * u.K
+        assert ct.temperature_setpoint == 0 * u.K
+        ct.temperature_setpoint = 100 * u.K
+        assert ct.temperature_setpoint == 100 * u.K
 
 
 def test_thermostat():
@@ -331,6 +330,6 @@ def test_query_warning():
         sep="\r",
     ) as ct:
         with pytest.warns(UserWarning) as warn:
-            ct.temperature_set = 0 * u.K
+            ct.temperature_setpoint = 0 * u.K
             assert "Set value 0" in warn[0].message.args[0]
             assert "returned value 77" in warn[0].message.args[0]

--- a/tests/test_sunpower/test_cryotel_gt.py
+++ b/tests/test_sunpower/test_cryotel_gt.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python
+"""
+Module containing tests for the Sunpower CryoTel GT
+"""
+
+# IMPORTS ####################################################################
+
+import pytest
+
+import instruments as ik
+from instruments.abstract_instruments.comm import GPIBCommunicator
+from instruments.units import ureg as u
+from tests import expected_protocol, make_name_test, unit_eq
+
+# TESTS ######################################################################
+
+# PROPERTIES #
+
+
+def test_at_temperature_band():
+    """Set/ get the at_temperature_band property of the CryoTel GT."""
+    with expected_protocol(
+        ik.sunpower.CryoTelGT,
+        ["SET TBAND", "SET TBAND=0.07", "SET TBAND"],
+        ["SET TBAND", "0.500", "SET TBAND=0.07", "0.07", "SET TBAND", "0.07"],
+        sep="\r",
+    ) as ct:
+        assert ct.at_temperature_band == 0.5 * u.K
+        ct.at_temperature_band = 0.07 * u.K
+        assert ct.at_temperature_band == 0.07 * u.K
+
+
+def test_control_mode():
+    """Set/ get the control_mode property of the CryoTel GT."""
+    with expected_protocol(
+        ik.sunpower.CryoTelGT,
+        ["SET PID", "SET PID=0", "SET PID"],
+        ["SET PID", "2", "SET PID=0", "0", "SET PID", "0"],
+        sep="\r",
+    ) as ct:
+        assert ct.control_mode == ct.ControlMode.TEMPERATURE
+        ct.control_mode = ct.ControlMode.POWER
+        assert ct.control_mode == ct.ControlMode.POWER
+
+        with pytest.raises(ValueError):
+            ct.control_mode = "invalid_mode"
+
+
+def test_errors():
+    """Get the error codes of the CryoTel GT and return error strings."""
+    with expected_protocol(
+        ik.sunpower.CryoTelGT,
+        ["ERROR"],  # , "ERROR", "ERROR"],
+        # ["ERROR", "100000", "ERROR", "000000", "ERROR", "011001"],
+        ["ERROR", "011001"],
+        sep="\r",
+    ) as ct:
+        # assert ct.errors == ["Temperature Sensor Error"]
+        # assert ct.errors == []
+        assert ct.errors == [
+            "Over Current",
+            "Non-volatile Memory Error",
+            "Watchdog Error",
+        ]
+
+
+def test_ki():
+    """Set/get the ki property of the CryoTel GT."""
+    with expected_protocol(
+        ik.sunpower.CryoTelGT,
+        ["SET KI", "SET KI=0.10", "SET KI"],
+        ["SET KI", "5.0", "SET KI=0.10", "0.1", "SET KI", "0.1"],
+        sep="\r",
+    ) as ct:
+        assert ct.ki == 5.0
+        ct.ki = 0.1
+        assert ct.ki == 0.1
+
+
+def test_kp():
+    """Set/get the kp property of the CryoTel GT."""
+    with expected_protocol(
+        ik.sunpower.CryoTelGT,
+        ["SET KP", "SET KP=0.10", "SET KP"],
+        ["SET KP", "0.5", "SET KP=0.10", "0.10", "SET KP", "0.10"],
+        sep="\r",
+    ) as ct:
+        assert ct.kp == 0.5
+        ct.kp = 0.1
+        assert ct.kp == 0.1
+
+
+def test_power():
+    """Get the current power of the CryoTel GT."""
+    with expected_protocol(
+        ik.sunpower.CryoTelGT,
+        ["P", "P"],
+        ["P", "0.00", "P", "500.0"],
+        sep="\r",
+    ) as ct:
+        assert ct.power == 0.0 * u.W
+        assert ct.power == 500 * u.W
+
+
+def test_power_current_and_limits():
+    """Get the current power and power limits of the CryoTel GT."""
+    with expected_protocol(
+        ik.sunpower.CryoTelGT,
+        ["E"],
+        ["P", "0.00", "500.00", "1000.00"],
+        sep="\r",
+    ) as ct:
+        assert ct.power_current_and_limits == (0.0 * u.W, 500 * u.W, 1000 * u.W)
+
+
+def test_power_max():
+    """Get/set the maximum user power."""
+    with expected_protocol(
+        ik.sunpower.CryoTelGT,
+        ["SET MAX", "SET MAX=100.00", "SET MAX"],
+        ["SET MAX", "10.0", "SET MAX=100.00", "100.0", "SET MAX", "100.0"],
+        sep="\r",
+    ) as ct:
+        assert ct.power_max == 10 * u.W
+        ct.power_max = 100 * u.W
+        assert ct.power_max == 100 * u.W
+
+        with pytest.raises(ValueError):
+            ct.power_max = 1000 * u.W
+        with pytest.raises(ValueError):
+            ct.power_max = -10 * u.W
+
+
+def test_power_min():
+    """Get/set the minimum user power."""
+    with expected_protocol(
+        ik.sunpower.CryoTelGT,
+        ["SET MIN", "SET MIN=10.00", "SET MIN"],
+        ["SET MIN", "0.0", "SET MIN=10.00", "10.0", "SET MIN", "10.0"],
+        sep="\r",
+    ) as ct:
+        assert ct.power_min == 0 * u.W
+        ct.power_min = 10 * u.W
+        assert ct.power_min == 10 * u.W
+
+        with pytest.raises(ValueError):
+            ct.power_min = 1000 * u.W
+        with pytest.raises(ValueError):
+            ct.power_min = -10 * u.W
+
+
+def test_power_set():
+    """Get/set the power setpoint of the CryoTel GT."""
+    with expected_protocol(
+        ik.sunpower.CryoTelGT,
+        ["SET PWOUT", "SET PWOUT=100.00", "SET PWOUT"],
+        ["SET PWOUT", "0.00", "SET PWOUT=100.00", "100.00", "SET PWOUT", "100.00"],
+        sep="\r",
+    ) as ct:
+        assert ct.power_set == 0 * u.W
+        ct.power_set = 100 * u.W
+        assert ct.power_set == 100 * u.W
+
+        with pytest.raises(ValueError):
+            ct.power_set = 1000 * u.W
+        with pytest.raises(ValueError):
+            ct.power_set = -10 * u.W
+
+
+def test_serial_number():
+    """Get the serial number of the CryoTel GT."""
+    with expected_protocol(
+        ik.sunpower.CryoTelGT,
+        ["SERIAL"],
+        ["SERIAL", "serial", "revision"],
+        sep="\r",
+    ) as ct:
+        assert ct.serial_number == ["serial", "revision"]
+
+
+def test_state():
+    """Get the state of the CryoTel GT."""
+    STATE_EXAMPLE = [
+        "MODE = 002.00",
+        "TSTATM = 000.00",
+        "TSTAT = 000.00",
+        "SSTOPM = 000.00",
+        "SSTOP = 000.00",
+        "PID = 002.00",
+        "LOCK = 000.00",
+        "MAX = 300.00",
+        "MIN = 000.00",
+        "PWOUT = 000.00",
+        "TTARGET = 000.00",
+        "TBAND = 000.50",
+        "KI = 000.50",
+        "KP = 050.00000",
+    ]
+    with expected_protocol(
+        ik.sunpower.CryoTelGT,
+        ["STATE"],
+        ["STATE"] + STATE_EXAMPLE,
+        sep="\r",
+    ) as ct:
+        assert ct.state == STATE_EXAMPLE
+
+
+def test_temperature():
+    """Get the temperature of the CryoTel GT."""
+    with expected_protocol(
+        ik.sunpower.CryoTelGT,
+        ["TC", "TC"],
+        ["TC", "77.00", "TC", "72.89"],
+        sep="\r",
+    ) as ct:
+        assert ct.temperature == 77.0 * u.K
+        assert ct.temperature == 72.89 * u.K
+
+
+def test_temperature_set():
+    """Get/set the temperature setpoint of the CryoTel GT."""
+    with expected_protocol(
+        ik.sunpower.CryoTelGT,
+        ["SET TTARGET", "SET TTARGET=100.00", "SET TTARGET"],
+        [
+            "SET TTARGET",
+            "0.00",
+            "SET TTARGET=100.00",
+            "100.00",
+            "SET TTARGET",
+            "100.00",
+        ],
+        sep="\r",
+    ) as ct:
+        assert ct.temperature_set == 0 * u.K
+        ct.temperature_set = 100 * u.K
+        assert ct.temperature_set == 100 * u.K
+
+
+def test_thermostat():
+    """Get/set the thermostat property of the CryoTel GT."""
+    with expected_protocol(
+        ik.sunpower.CryoTelGT,
+        ["SET TSTATM", "SET TSTATM=1", "SET TSTATM"],
+        ["SET TSTATM", "0", "SET TSTATM=1", "1", "SET TSTATM", "1"],
+        sep="\r",
+    ) as ct:
+        assert ct.thermostat is False
+        ct.thermostat = True
+        assert ct.thermostat is True
+
+        with pytest.raises(ValueError):
+            ct.thermostat = "invalid_value"
+
+
+def test_thermostat_status():
+    """Get the thermostat status of the CryoTel GT."""
+    with expected_protocol(
+        ik.sunpower.CryoTelGT,
+        ["TSTAT", "TSTAT"],
+        ["TSTAT", "0.00", "TSTAT", "1.00"],
+        sep="\r",
+    ) as ct:
+        assert ct.thermostat_status == ct.ThermostatStatus.OFF
+        assert ct.thermostat_status == ct.ThermostatStatus.ON
+
+
+def test_stop():
+    """Get/set the soft stop property of the CryoTel GT to turn it off."""
+    with expected_protocol(
+        ik.sunpower.CryoTelGT,
+        ["SET SSTOP", "SET SSTOP=1", "SET SSTOP"],
+        ["SET SSTOP", "0", "SET SSTOP=1", "1", "SET SSTOP", "1"],
+        sep="\r",
+    ) as ct:
+        assert ct.stop is False
+        ct.stop = True
+        assert ct.stop is True
+
+        with pytest.raises(ValueError):
+            ct.stop = "invalid_value"
+
+
+def test_stop_mode():
+    """Get/set the stop mode of the CryoTel GT."""
+    with expected_protocol(
+        ik.sunpower.CryoTelGT,
+        ["SET SSTOPM", "SET SSTOPM=1", "SET SSTOPM"],
+        ["SET SSTOPM", "0", "SET SSTOPM=1", "1", "SET SSTOPM", "1"],
+        sep="\r",
+    ) as ct:
+        assert ct.stop_mode == ct.StopMode.HOST
+        ct.stop_mode = ct.StopMode.DIGIO
+        assert ct.stop_mode == ct.StopMode.DIGIO
+
+        with pytest.raises(ValueError):
+            ct.stop_mode = "invalid_mode"
+
+
+# METHODS #
+
+
+def test_reset():
+    """Reset the CryoTel GT."""
+    with expected_protocol(
+        ik.sunpower.CryoTelGT,
+        ["RESET=F"],
+        ["RESET=F", "RESETTING TO FACTORY DEFAULT...", "FACTORY RESET COMPLETE!"],
+        sep="\r",
+    ) as ct:
+        ct.reset()
+
+
+def test_save_control_mode():
+    """Save the current control mode of the CryoTel GT."""
+    with expected_protocol(
+        ik.sunpower.CryoTelGT,
+        ["SAVE PID"],
+        ["SAVE PID"],
+        sep="\r",
+    ) as ct:
+        ct.save_control_mode()
+
+
+def test_query_warning():
+    """Raise a warning if a value was not set because not accepted."""
+    with expected_protocol(
+        ik.sunpower.CryoTelGT,
+        ["SET TTARGET=0.00"],
+        ["SET TTARGET=0.00", "77.00"],
+        sep="\r",
+    ) as ct:
+        with pytest.warns(UserWarning) as warn:
+            ct.temperature_set = 0 * u.K
+            assert "Set value 0" in warn[0].message.args[0]
+            assert "returned value 77" in warn[0].message.args[0]


### PR DESCRIPTION
This PR adds support for the Sunpower/Ametek CryoTel GT cryocooler. The generation 2 driver was used, which works for devices purchased after May 2012. This is also noted in the driver itself.

Added tests for full coverage and tested extensively in lab. 

Error code handling: Currently returns a list of human readable strings that is calculated from the return using a bitmask... maybe not the most fancy way of doing it.

As always, let me know what you think!