### PR TITLE
Allow move_indefinitely to move in the 'negative' direction

### DIFF
--- a/src/instruments/newport/newportesp301.py
+++ b/src/instruments/newport/newportesp301.py
@@ -84,7 +84,7 @@ class NewportESP301(Instrument):
 
             self._controller = controller
             self._axis_id = axis_id + 1
-            #self._direction = "+"
+
             self._units = self.units
 
         # CONTEXT MANAGERS ##
@@ -139,19 +139,6 @@ class NewportESP301(Instrument):
             :type: `bool`
             """
             return bool(int(self._newport_cmd("MD?", target=self.axis_id)))
-
-        # @property
-        # def direction(self):
-        #     """
-        #     Either '+' or '-' depending on last velocity sign.
-        #     """
-        #     return self._direction
-
-        # @direction.setter
-        # def direction(self, sign):
-        #     if sign not in ('+', '-'):
-        #         raise ValueError("Direction must be '+' or '-'")
-        #         self._direction = sign
 
         @property
         def acceleration(self):
@@ -266,7 +253,6 @@ class NewportESP301(Instrument):
 
         @velocity.setter
         def velocity(self, velocity):
-            #self._direction = '+' if velocity > 0 else '-'
             velocity = abs(velocity)
             velocity = float(
                 assume_units(velocity, self._units / (u.s))
@@ -1010,7 +996,6 @@ class NewportESP301(Instrument):
             self.voltage = kwargs.get("voltage")
             self.units = int(kwargs.get("units"))
             self.encoder_resolution = kwargs.get("encoder_resolution")
-            #self.direction = kwargs.get("direction")
             self.max_acceleration = kwargs.get("max_acceleration")
             self.max_velocity = kwargs.get("max_velocity")
             self.max_base_velocity = kwargs.get("max_base_velocity")
@@ -1099,7 +1084,6 @@ class NewportESP301(Instrument):
             config["full_step_resolution"] = self.full_step_resolution
             config["position_display_resolution"] = self.position_display_resolution
             config["current"] = self.current
-            #config["direction"] = self.direction
             config["max_velocity"] = self.max_velocity
             config["encoder_resolution"] = self.encoder_resolution
             config["acceleration"] = self.acceleration

--- a/src/instruments/newport/newportesp301.py
+++ b/src/instruments/newport/newportesp301.py
@@ -42,7 +42,6 @@ class NewportESP301(Instrument):
         self._command_list = []
         self._bulk_query_resp = ""
         self.terminator = "\r"
-        
 
     class Axis:
         """
@@ -870,7 +869,7 @@ class NewportESP301(Instrument):
             """
             self._newport_cmd("MT", target=self.axis_id)
 
-        def move_indefinitely(self, direction: str = '+'):
+        def move_indefinitely(self, direction: str = "+"):
             """
             Move until told to stop in the direction ("+" or "-") passed.
             """

--- a/src/instruments/newport/newportesp301.py
+++ b/src/instruments/newport/newportesp301.py
@@ -84,7 +84,7 @@ class NewportESP301(Instrument):
 
             self._controller = controller
             self._axis_id = axis_id + 1
-            self.direction = "+"
+            self._direction = "+"
             self._units = self.units
 
         # CONTEXT MANAGERS ##
@@ -145,13 +145,13 @@ class NewportESP301(Instrument):
             """
             Either '+' or '-' depending on last velocity sign.
             """
-            return self.direction
+            return self._direction
 
         @direction.setter
         def direction(self, sign):
             if sign not in ('+', '-'):
                 raise ValueError("Direction bust be '+' or '-'")
-                self.direction = sign
+                self._direction = sign
 
         @property
         def acceleration(self):
@@ -266,7 +266,7 @@ class NewportESP301(Instrument):
 
         @velocity.setter
         def velocity(self, velocity):
-            self.direction = '+' if velocity > 0 else '-'
+            self._direction = '+' if velocity > 0 else '-'
             velocity = abs(velocity)
             velocity = float(
                 assume_units(velocity, self._units / (u.s))
@@ -888,7 +888,7 @@ class NewportESP301(Instrument):
             """
             Move until told to stop
             """
-            self._newport_cmd(f"MV{self.direction}", target=self.axis_id)
+            self._newport_cmd(f"MV{self._direction}", target=self.axis_id)
 
         def abort_motion(self):
             """

--- a/src/instruments/newport/newportesp301.py
+++ b/src/instruments/newport/newportesp301.py
@@ -888,7 +888,7 @@ class NewportESP301(Instrument):
             """
             Move until told to stop in the direction ("+" or "-") passed.
             """
-            if direction is not in ("+", "-"):
+            if direction not in ("+", "-"):
                 raise ValueError("Direction must be '+' or '-'")
             self._newport_cmd(f"MV{direction}", target=self.axis_id)
 

--- a/src/instruments/newport/newportesp301.py
+++ b/src/instruments/newport/newportesp301.py
@@ -84,7 +84,7 @@ class NewportESP301(Instrument):
 
             self._controller = controller
             self._axis_id = axis_id + 1
-            self._direction = "+"
+            #self._direction = "+"
             self._units = self.units
 
         # CONTEXT MANAGERS ##
@@ -140,18 +140,18 @@ class NewportESP301(Instrument):
             """
             return bool(int(self._newport_cmd("MD?", target=self.axis_id)))
 
-        @property
-        def direction(self):
-            """
-            Either '+' or '-' depending on last velocity sign.
-            """
-            return self._direction
+        # @property
+        # def direction(self):
+        #     """
+        #     Either '+' or '-' depending on last velocity sign.
+        #     """
+        #     return self._direction
 
-        @direction.setter
-        def direction(self, sign):
-            if sign not in ('+', '-'):
-                raise ValueError("Direction bust be '+' or '-'")
-                self._direction = sign
+        # @direction.setter
+        # def direction(self, sign):
+        #     if sign not in ('+', '-'):
+        #         raise ValueError("Direction must be '+' or '-'")
+        #         self._direction = sign
 
         @property
         def acceleration(self):
@@ -266,7 +266,7 @@ class NewportESP301(Instrument):
 
         @velocity.setter
         def velocity(self, velocity):
-            self._direction = '+' if velocity > 0 else '-'
+            #self._direction = '+' if velocity > 0 else '-'
             velocity = abs(velocity)
             velocity = float(
                 assume_units(velocity, self._units / (u.s))
@@ -884,11 +884,13 @@ class NewportESP301(Instrument):
             """
             self._newport_cmd("MT", target=self.axis_id)
 
-        def move_indefinitely(self):
+        def move_indefinitely(self, direction: str = '+'):
             """
-            Move until told to stop
+            Move until told to stop in the direction ("+" or "-") passed.
             """
-            self._newport_cmd(f"MV{self._direction}", target=self.axis_id)
+            if direction is not in ("+", "-"):
+                raise ValueError("Direction must be '+' or '-'")
+            self._newport_cmd(f"MV{direction}", target=self.axis_id)
 
         def abort_motion(self):
             """
@@ -971,7 +973,6 @@ class NewportESP301(Instrument):
             * 'voltage' = motor voltage (V)
             * 'units' = set units (see NewportESP301.Units)(U)
             * 'encoder_resolution' = value of encoder step in terms of (U)
-            * 'direction' = sign of velocity ('+' or '-')
             * 'max_velocity' = maximum velocity (U/s)
             * 'max_base_velocity' =  maximum working velocity (U/s)
             * 'homing_velocity' = homing speed (U/s)
@@ -1009,7 +1010,7 @@ class NewportESP301(Instrument):
             self.voltage = kwargs.get("voltage")
             self.units = int(kwargs.get("units"))
             self.encoder_resolution = kwargs.get("encoder_resolution")
-            self.direction = kwargs.get("direction")
+            #self.direction = kwargs.get("direction")
             self.max_acceleration = kwargs.get("max_acceleration")
             self.max_velocity = kwargs.get("max_velocity")
             self.max_base_velocity = kwargs.get("max_base_velocity")
@@ -1098,7 +1099,7 @@ class NewportESP301(Instrument):
             config["full_step_resolution"] = self.full_step_resolution
             config["position_display_resolution"] = self.position_display_resolution
             config["current"] = self.current
-            config["direction"] = self.direction
+            #config["direction"] = self.direction
             config["max_velocity"] = self.max_velocity
             config["encoder_resolution"] = self.encoder_resolution
             config["acceleration"] = self.acceleration


### PR DESCRIPTION
This change allows the NewportESP301 to take a direction argument when calling the 'move_indefinitely' function. Currently, this function only allows movement in the 'positive' direction. By adding an optional 'direction' argument, the function can be used in either direction. This update should not affect any existing code, as the default if no argument is passed will still be positive movement.