### PR TITLE
Fix LCC25 voltage min step value to 1mV

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+default_language_version:
+  python: /c/tools/Anaconda3/python
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,3 @@
-default_language_version:
-  python: /c/tools/Anaconda3/python
-
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/src/instruments/thorlabs/lcc25.py
+++ b/src/instruments/thorlabs/lcc25.py
@@ -133,7 +133,7 @@ class LCC25(Instrument):
     voltage1 = unitful_property(
         "volt1",
         u.V,
-        format_code="{:.1f}",
+        format_code="{:.3f}",
         set_fmt="{}={}",
         valid_range=(0, 25),
         doc="""
@@ -148,7 +148,7 @@ class LCC25(Instrument):
     voltage2 = unitful_property(
         "volt2",
         u.V,
-        format_code="{:.1f}",
+        format_code="{:.3f}",
         set_fmt="{}={}",
         valid_range=(0, 25),
         doc="""
@@ -163,7 +163,7 @@ class LCC25(Instrument):
     min_voltage = unitful_property(
         "min",
         u.V,
-        format_code="{:.1f}",
+        format_code="{:.3f}",
         set_fmt="{}={}",
         valid_range=(0, 25),
         doc="""
@@ -178,7 +178,7 @@ class LCC25(Instrument):
     max_voltage = unitful_property(
         "max",
         u.V,
-        format_code="{:.1f}",
+        format_code="{:.3f}",
         set_fmt="{}={}",
         valid_range=(0, 25),
         doc="""
@@ -209,7 +209,7 @@ class LCC25(Instrument):
     increment = unitful_property(
         "increment",
         units=u.V,
-        format_code="{:.1f}",
+        format_code="{:.3f}",
         set_fmt="{}={}",
         valid_range=(0, None),
         doc="""


### PR DESCRIPTION
Modified lcc25.py to make the script match the stepsize of the instrument LCC25 by modifying the associated f-string.